### PR TITLE
tweak get_dev_identifier() more matching options. Multi-dev select

### DIFF
--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -85,7 +85,8 @@ def short_value(key: str, value: Any):
     # _unlist(value)
 
     if isinstance(value, (str, int, float)):
-        return short_key(key), _short_value.get(value, value) if key not in _short_value else _short_value[key](value)
+        return short_key(key), _short_value.get(value, value) \
+               if key not in _short_value or not value else _short_value[key](value)
     else:
         return short_key(key), _unlist(value)
 


### PR DESCRIPTION
Will now attempt to find matches replacing - with _ and visa versa
Then will look for matches that start with the provided id.

If multiple devices match user is prompted to select from the resulting match

**NOTE: Still need to re-factor the query**
dev_identifier doesn't factor in the dev type so ...
`show switch bsmt-` could return an AP with a name that starts with `bsmt-`