### PR TITLE
sticky account name, and lots of formatting work

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -57,6 +57,10 @@ class Cache:
     def all(self) -> dict:
         return {t.name: getattr(self, t.name) for t in self._tables}
 
+    @property
+    def prev_acct(self) -> str:
+        return self.MetaDB.get(doc_id=1).get("prev_account")
+
     # TODO deprecated should be able to remove this method
     def insert(self, data: Union[List[dict, ], dict]) -> bool:
         _data = data
@@ -186,7 +190,7 @@ class Cache:
             query_str = " ".join(query_str)
 
         match = None
-        for i in range(0, 2 if retry else 1):
+        for _ in range(0, 2 if retry else 1):
             # Try exact match
             match = self.DevDB.search((self.Q.name == query_str) | (self.Q.ip == query_str)
                                       | (self.Q.mac == utils.Mac(query_str).cols) | (self.Q.serial == query_str))

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -25,6 +25,7 @@ class Config:
         self.stored_tasks_file = self.dir / "stored-tasks.yaml"
         self.cache_dir = self.dir / ".cache"
         self.default_cache_file = self.cache_dir / "db.json"
+        self.sticky_account_file = self.cache_dir / "last_account"
         self.data = self.get_config_data(self.file) or {}
         self.debug = self.data.get("debug", False)
         self.debugv = self.data.get("debugv", False)


### PR DESCRIPTION
`--account` is now sticky.  `-d` can be used as shorthand to return to default account.
By default it's sticky forever, but 
` forget_account_after: 30` can be set in the config, then the account will return to default 30 mins after last command.

more work with rich library.  it will fit output to tty size automatically and fold or ... the output in the col, still needs more work, but looks promising.

Also all device outputs, not strip all cols that have no value (or `Unknown`) for all devices.
