### PR TITLE
Change config dir location logic.

### DIFF
--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -32,13 +32,13 @@ else:
         print("Warning Logic Error in git/pypi detection")
         print(f"base_dir Parts: {base_dir.parts}")
 
-log_dir = base_dir / "logs"
-log_dir.mkdir(parents=True, exist_ok=True)
-log_file = log_dir / f"{__name__}.log"
-
 from .logger import MyLogger
 from .config import Config
 config = Config(base_dir=base_dir)
+
+log_dir = base_dir / "logs"
+log_dir.mkdir(parents=True, exist_ok=True)
+log_file = log_dir / f"{__name__}.log"
 
 if '--debug' in str(sys.argv):
     config.debug = True  # for the benefit of the 2 log messages below

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -272,9 +272,9 @@ def sort_device_keys(data: List[dict]) -> List[dict]:
                     mask = ipaddress.IPv4Network((inner['ip_address'], inner['subnet_mask']), strict=False).prefixlen
                     inner['ip_address'] = f"{inner['ip_address']}/{mask}"
                     del inner['subnet_mask']
-                if inner.get('public_ip_address'):
-                    inner['ip_address'] += f'\npublic: {inner["public_ip_address"]}'
-                    del inner["public_ip_address"]
+                # if inner.get('public_ip_address'):
+                #     inner['ip_address'] += f'\npublic: {inner["public_ip_address"]}'
+                #     del inner["public_ip_address"]
 
     to_front = [
         'name',

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -215,7 +215,7 @@ def display_results(data: Union[List[dict], List[str], None], tablefmt: str = "s
 
         # -- // Output to file \\ --
         if outfile and outdata:
-            if outfile.parent.resolve() == config.base_dir.resolve():
+            if Path.joinpath(outfile.parent.resolve() / ".git").is_dir():
                 config.outdir.mkdir(exist_ok=True)
                 outfile = config.outdir / outfile
 
@@ -309,7 +309,7 @@ def aps(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -343,7 +343,7 @@ def switches(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -372,7 +372,7 @@ def interfaces(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -410,7 +410,7 @@ def all(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -444,7 +444,7 @@ def devices(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -495,7 +495,7 @@ def gateways(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -529,7 +529,7 @@ def controllers(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -553,7 +553,7 @@ def cache(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Alpha Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -576,7 +576,7 @@ def cache(
 
 @app.command(short_help="Show groups/details")
 def groups(
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
                                  callback=default_callback),
@@ -602,7 +602,7 @@ def sites(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     sort_by: SortOptions = typer.Option(None, "--sort"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
@@ -649,7 +649,7 @@ def templates(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     sort_by: SortOptions = typer.Option(None, "--sort"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
@@ -727,7 +727,7 @@ def variables(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     sort_by: SortOptions = typer.Option(None, "--sort"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
@@ -759,7 +759,7 @@ def lldp(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     sort_by: SortOptions = typer.Option(None, "--sort"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
@@ -789,7 +789,7 @@ def certs(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     sort_by: SortOptions = typer.Option(None, "--sort"),
     no_pager: bool = typer.Option(False, "--no-pager", help="Disable Paged Output"),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
@@ -820,7 +820,7 @@ def clients(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     sort_by: SortOptions = typer.Option(None, "--sort", hidden=True,),  # TODO Unhide after implemented
     reverse: SortOptions = typer.Option(None, "-r", hidden=True,),  # TODO Unhide after implemented
@@ -863,7 +863,7 @@ def logs(
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_rich: bool = typer.Option(False, "--rich", is_flag=True, help="Beta Testing rich formatter"),
-    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
     sort_by: SortOptions = typer.Option(None, "--sort", hidden=True,),  # TODO Unhide after implemented
     reverse: SortOptions = typer.Option(None, "-r", hidden=True,),  # TODO Unhide after implemented

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -283,7 +283,7 @@ class Utils:
 
     class Output:
         def __init__(self, rawdata: str = "", prettydata: str = ""):
-            self.file = rawdata    # found typer.unstyle AFTER I built this
+            # self.file = rawdata    # found typer.unstyle AFTER I built this
             self.tty = prettydata
 
         def __len__(self):
@@ -301,6 +301,10 @@ class Utils:
             out = self.tty or self.file
             for line in out.splitlines(keepends=True):
                 yield line
+
+        @property
+        def file(self):
+            return typer.unstyle(self.tty)
 
     # Not used moved to __str__ method of Output class
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.4a12"
+version = "0.4a15"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
Found on windows with pypi install that
typer.get_app_dir(__name__) returned the full path
in site_packages, not what we want.

program now looks for config in a number of places:
```
            [
                Path().home() / ".config" / "centralcli",
                Path().home() / ".centralcli",
                cwd / "config",
                cwd,
                Path().home() / ".config" / "centralcli" / "config",
            ]
```
If the config file is in any of those then that's what is
used, and directory structure is derived from there.