### PR TITLE
fix Windows config_dir

### DIFF
--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -40,11 +40,14 @@ class Config:
             else:
                 self.outdir = self.dir.parent / "out"
         else:
-            if str(Path('.config/centralcli')) in self.base_dir:
+            if str(Path('.config/centralcli')) in str(self.base_dir):
                 self.dir = self.base_dir
                 self.outdir = cwd / "out"
             else:
-                self.dir = self.base_dir / "config"
+                if 'site-packages' in str(self.base_dir):
+                    self.base_dir = self.dir = Path().home() / ".centralcli"
+                else:
+                    self.dir = self.base_dir / "config"
                 self.outdir = self.base_dir / "out"
             self.file = self.dir / "config.yaml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.4a15"
+version = "0.4a16"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
Update after testing last merge, still needed minor tweak.

will now default to `%HOME%\.centralcli` for Windows.
if typer.get_config_dir() yileds package directory.

Technically for any OS, but typer.get_config_dir() returns a logical value for *nix based systems
`~/.config/centralcli on linux`