### PR TITLE
Build Out ReadMe, re-factor namespaces, common cli object

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,4 +18,8 @@
     "cSpell.ignoreWords": [
         "secho"
     ],
+    "cSpell.words": [
+        "cencli",
+        "centralcli"
+    ],
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ---
 
-A CLI app for interacting with Aruba Central Clound Management Platform. With cross-platform / shell support. i.e. Bash, zsh, PowerShell, etc.
+A CLI app for interacting with Aruba Central Cloud Management Platform. With cross-platform / shell support. i.e. Bash, zsh, PowerShell, etc.
+
+`TODO [demo](docs/media/demo.gif)`
 
 ## Features
 - Cross Platform Support
@@ -11,14 +13,82 @@ A CLI app for interacting with Aruba Central Clound Management Platform. With cr
 - multiple output formats
 - output to file
 - multiple account support (easily switch between different central accounts)
+- Batch Operation based on data from input file.  i.e. Add sites in batch based on data from a csv.
 
 ## Installation
 Requires python3 and pip
 
 `pip3 install centralcli`
 
-### Configuration
+> You can also install in a virtual environment (venv), but you'll lose auto-completion, unless you activate the venv.
 
-TODO Change pending config file location change, will look in user home .config/centralcli on all platforms and won't have the extra config subdir (currently ~/.config/centralcli/config) derived by click... just noticed on Windows the path is the config folder in site-packages, not what we want.
+## Configuration
 
 Refer to [config.yaml.example](config/config.yaml.example) to guide in the creation of config.yaml and place in the config directory.
+
+CentralCli will look in \<Users home dir\>/.config/centralcli, and \<Users home dir\>/.centralcli.
+i.e. on Windows `c:\Users\wade\.centralcli` or on Linux `/home/wade/.config/centralcli`
+
+Once `config.yaml` is populated per [config.yaml.example](config/config.yaml.example), run some test commands to validate the config.
+
+Example test command `cencli show all`
+
+```bash
+wade@wellswa6:~ $ cli show all
+✔ Collecting Data [monitoring/v1/switches]
+✔ Collecting Data [monitoring/v2/aps]
+✔ Collecting Data [monitoring/v1/gateways]
+name               ip               mac            model                 group          site     serial      type     labels       version                status
+-----------------  ---------------  -------------  --------------------  -------------  -------  ----------  -------  -----------  ---------------------  --------
+BR1_315_0c:88      10.101.6.200/24  --redacted--   315                   Branch1        Antigua  -redacted-  ap       Branch View  8.7.1.1_78245          Up
+IAP305             10.2.30.102      --redacted--   305                   TemplateGroup           -redacted-  ap                    6.5.1.0-4.3.1.2_58595  Down
+LABAP4             10.0.30.233/24   --redacted--   345                   WadeLab                 -redacted-  ap                    8.7.1.0_77203          Down
+sw-zippity                          --redacted--   J9773A                WadeLab                 -redacted-  SW                    16.10.000x             Down
+sw-ConsolePi-dev   10.0.10.154      --redacted--   Aruba2930F-(JL258A)   WadeLab        WadeLab  -redacted-  SW                    16.10.0011             Down
+2930F-Branch1      10.101.5.4       --redacted--   Aruba2930F-(JL258A)   Branch1        Antigua  -redacted-  SW       Branch View  16.10.0007             Up
+6200F-Bot          10.0.40.16       --redacted--   6200F 48G-(JL728A)    WadeLab        WadeLab  -redacted-  CX                    10.06.0010             Up
+SDBranch1:7008     192.168.240.101  --redacted--   A7008                 Branch1        Antigua  -redacted-  gateway  Branch View  8.5.0.0-2.0.0.6_76205  Up
+VPNC1              192.168.30.201   --redacted--   A7005                 WadeLab        WadeLab  -redacted-  gateway  Branch View  8.6.0.4-2.2.0.3_77966  Up
+VPNC2              192.168.30.202   --redacted--   A7005                 WadeLab        WadeLab  -redacted-  gateway  Branch View  8.6.0.4-2.2.0.3_77966  Up
+...
+
+```
+
+Use cencli --help to become familiar with the command options.
+> *NOTE:* Aruba Central API CLI is still evolving.  Structure and the format of outputs are likely to change over time.
+
+### Auto Completion
+The CLI supports auto-completion.  To configure auto-completion run `cencli --install-completion`.  This will auto-detect the type of shell you are running in, and install the necessary completion into your profile.  You'll need to exit the shell and start a new session for it to take effect.
+
+## Usage Notes:
+
+### Caching & Friendly identifiers
+- Caching: The CLI caches information on all devices, sites, groups, and templates in Central.  It's a minimal amount per device, and is done to allow human friendly identifiers.  The API typically accepts serial #, site id, etc.  This function allows you to specify a dev for example by name, IP, mac (any format), and serial.
+The lookup sequence for a device:
+
+    1. Exact Match of any of the identifier fields (name, ip, mac, serial)
+    2. case insensitive match
+    3. case insensitive match disregarding all hyphens and underscores (in case you type 6200f_bot and the device name is 6200F-Bot)
+    4. Case insensitive Fuzzy match with implied wild-card, otherwise match any devices that start with the identifier provided. `cencli show switches 6200F` will result in a match of `6200F-Bot`.
+
+> If there is no match found, a cache update is triggered in most scenarios, and the match rules are re-tried.  The cache is also updated every 3 hours (if you run a command and it's older than 3 hours, it will update the cache first).  This update 3 hour update will be removed in a future release once auto-update/retry is implemented for all identifier types (groups, and templates currently lack the update/retry bit)
+
+- Caching works in a similar manner for groups, templates, and sites.  Sites can match on name and nearly any address field.  So if you only had one site in San Antonio you could specify that site with `show sites 'San Antonio'`  \<-- Note the use of quotes because there is a space in the name.
+
+- **Multiple Matches**:  It's possible to specify an identifier that returns multiple matches (if drops all the way down to the Fuzzy match/implied trailing wild-card).  If that occurs you are prompted to select the intended device from a list of the matches.
+
+### Output Formats
+
+There are a number of output formats available.  Most commands default to what is likely the easiest to view given the number of fields.  Otherwise longer outputs are typically displayed vertically by default.  If the output can reasonably fit, it's displayed in tabular format horizontally.
+
+You can specify the output format with command line flags `--json`, `--yaml`, `--csv`, `--rich`  rich is tabular format with folding (multi line within the same row) and truncating.
+
+> Most outputs will evolve to support an output with the most commonly desired fields by default and expanded vertical output via the `-v` option (not implemented yet.)
+
+### File Output
+
+Just use --out \<filename\> (or \<path\\filename\>), and specify the desired format.
+
+## CLI Tree
+
+Use `--help`, which you can do at any level.  `cli --help`, `cli do --help` etc.  A Tree will be documented here once it's built out more.

--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -53,6 +53,8 @@ from .utils import Utils
 utils = Utils()
 from .cache import Cache
 from .response import Response
+from .clicommon import CLICommon
+cli = CLICommon()
 
 
 if os.environ.get("TERM_PROGRAM") == "vscode":

--- a/centralcli/caas.py
+++ b/centralcli/caas.py
@@ -41,6 +41,7 @@ def eval_caas_response(resp) -> None:
                     typer.echo(f"\t{_r_txt}")
         typer.echo("")
 
+
 # def caasapi(self, group_dev: str, cli_cmds: list = None):
 #     if ":" in group_dev and len(group_dev) == 17:
 #         key = "node_name"

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -83,7 +83,7 @@ def get_conn_from_file(account_name, logger: MyLogger = log):
 class CentralApi(Session):
     def __init__(self, account_name: str = "central_info"):
         self.auth = get_conn_from_file(account_name)
-        super().__init__(central=self.auth)
+        super().__init__(auth=self.auth)
 
     async def _request(self, func, *args, **kwargs):
         async with ClientSession() as self.aio_session:
@@ -1293,7 +1293,6 @@ class CentralApi(Session):
         else:
             return await self.post(url, json_data=json_data, callback=cleaner._unlist)
 
-    # TODO move to caas.py
     async def caasapi(self, group_dev: str, cli_cmds: list = None):
         if ":" in group_dev and len(group_dev) == 17:
             key = "node_name"

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -1,33 +1,30 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import asyncio
-import time
-from pathlib import Path
-from typing import Any, List, Union
-# import clishow
-# import clido
-from tinydb import TinyDB
 import sys
+from pathlib import Path
+from typing import List
+
 import typer
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import config, log, utils, Cache, Response, caas, clishow, clido
+    from centralcli import clibatch, clicaas, clido, clishow, cli, log, utils
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import config, log, utils, Cache, Response, caas, clishow, clido
+        from centralcli import (clibatch, clicaas, clido, clishow, cli, log,
+                                utils)
     else:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.central import CentralApi
-from centralcli.constants import (TemplateLevel1,
-                                  RefreshWhat, arg_to_what)
-
-
-TinyDB.default_table_name = "devices"
+# cache, session = None, None  # Updated by cli.account_name_callback
+from centralcli.central import CentralApi  # noqa
+from centralcli.constants import (RefreshWhat, TemplateLevel1,  # noqa
+                                  arg_to_what)
 
 STRIP_KEYS = ["data", "devices", "mcs", "group", "clients", "sites", "switches", "aps"]
 SPIN_TXT_AUTH = "Establishing Session with Aruba Central API Gateway..."
@@ -38,182 +35,10 @@ tty = utils.tty
 app = typer.Typer()
 app.add_typer(clishow.app, name="show")
 app.add_typer(clido.app, name="do")
+app.add_typer(clibatch.app, name="batch")
+app.add_typer(clicaas.app, name="caas", hidden=True)
 
 
-class AcctMsg:
-    def __init__(self, account: str = None, msg: str = None) -> None:
-        self.account = account
-        self.msg = msg
-
-    def __repr__(self) -> str:
-        return str(self)
-
-    def __str__(self) -> str:
-        if self.msg and hasattr(self, self.msg):
-            return getattr(self, self.msg)
-        else:
-            return self.initial
-
-    @property
-    def initial(self):
-        acct_clr = f"{typer.style(self.account, fg='cyan')}"
-        return (
-            f"{typer.style(f'Using Account: {acct_clr}.', fg='magenta')}  "
-            f"{typer.style(f'Account setting is sticky.  ', fg='red', blink=True)}"
-            f"\n  {acct_clr} {typer.style(f'will be used for subsequent commands until', fg='magenta')}"
-            f"\n  {typer.style('--account <account name> or `-d` (revert to default). is used.', fg='magenta')}"
-        )
-
-    @property
-    def previous(self):
-        return (
-            f"{typer.style(f'Using previously specified account: ', fg='magenta')}"
-            f"{typer.style(self.account, fg='cyan', blink=True)}.  "
-            f"\n{typer.style('Use `--account <account name>` to switch to another account.', fg='magenta')}"
-            f"\n{typer.style('    or `-d` flag to revert to default account.', fg='magenta')}"
-        )
-
-    @property
-    def forgot(self):
-        typer.style(
-            "Forget option set for account, and expiration has passed.  reverting to default account",
-            fg="magenta"
-        )
-
-    @property
-    def will_forget(self):
-        return typer.style(
-            f'Forget options is configured, will revert to default account '
-            f'{typer.style(f"{config.forget_account_after} mins", fg="cyan")}'
-            f'{typer.style(" after last command.", fg="magenta")}',
-            fg="magenta"
-        )
-
-    @property
-    def previous_will_forget(self):
-        return f'{self.previous}\n\n{self.will_forget}'
-
-
-def default_callback(ctx: typer.Context, default: bool):
-    if ctx.resilient_parsing:  # tab completion, return without validating
-        return
-
-    if default and config.sticky_account_file.is_file():
-        typer.secho('Using default central account', fg="cyan")
-        config.sticky_account_file.unlink()
-
-
-# TODO ?? make more sense to have this return the ArubaCentralBase object ??
-def account_name_callback(ctx: typer.Context, account: str):
-    if ctx.resilient_parsing:  # tab completion, return without validating
-        return account
-
-    # -- // sticky last account caching and messaging \\ --
-    if account == "central_info":
-        if config.sticky_account_file.is_file():
-            last_account, last_cmd_ts = config.sticky_account_file.read_text().split('\n')
-            last_cmd_ts = float(last_cmd_ts)
-
-            # delete last_account file if they've configured forget_account_after
-            if config.forget_account_after:
-                if time.time() > last_cmd_ts + (config.forget_account_after * 60):
-                    config.sticky_account_file.unlink(missing_ok=True)
-                    typer.echo(AcctMsg(msg="forgot"))
-                else:
-                    account = last_account
-                    typer.echo(AcctMsg(account, msg='previous_will_forget'))
-            else:
-                account = last_account
-                typer.echo(AcctMsg(account, msg='previous'))
-    else:
-        if account in config.data:
-            config.sticky_account_file.write_text(f'{account}\n{round(time.time(), 2)}')
-            typer.echo(AcctMsg(account))
-
-    if account in config.data:
-        config.account = account
-        global session
-        session = CentralApi(account)
-        global cache
-        cache = Cache(session)
-        return account
-    else:
-        strip_keys = ['central_info', 'ssl_verify', 'token_store', 'forget_account_after', 'debug', 'debugv', 'limit']
-        typer.echo(f"{typer.style('ERROR:', fg=typer.colors.RED)} "
-                   f"The specified account: '{account}' is not defined in the config @\n"
-                   f"{config.file}\n\n")
-
-        _accounts = [k for k in config.data.keys() if k not in strip_keys]
-        if _accounts:
-            typer.echo(f"The following accounts are defined {_accounts}\n"
-                       f"The default account 'central_info' is used if no account is specified via --account flag.\n"
-                       f"or the ARUBACLI_ACCOUNT environment variable.\n")
-        else:
-            if not config.data:
-                # TODO prompt user for details
-                typer.secho("Configuration doesn't exist", fg="red")
-            else:
-                typer.secho("No accounts defined in config", fg="red")
-
-        if account != "central_info" and "central_info" not in config.data:
-            typer.echo(f"{typer.style('WARNING:', fg='yellow')} "
-                       f"'central_info' is not defined in the config.  This is the default when not overriden by\n"
-                       f"--account parameter or ARUBACLI_ACCOUNT environment variable.")
-
-        raise typer.Exit(code=1)
-
-
-def debug_callback(debug: bool):
-    if debug:
-        log.DEBUG = config.debug = debug
-
-
-@app.command()
-def bulk_edit(input_file: str = typer.Argument(None)):
-    cli = caas.BuildCLI(session=session)
-    # TODO log cli
-    if cli.cmds:
-        for dev in cli.data:
-            group_dev = f"{cli.data[dev]['_common'].get('group')}/{dev}"
-            resp = session.caasapi(group_dev, cli.cmds)
-            caas.eval_caas_response(resp)
-
-
-def eval_resp(resp: Response, pad: int = 0) -> Any:
-    if not resp.ok:
-        msg = f"{' ' * pad}{typer.style('ERROR:', fg=typer.colors.RED)} "
-        if isinstance(resp.output, dict):
-            msg += f"{resp.output.get('description', resp.error).replace('Error: ', '')}"
-        else:
-            msg += str(resp.output)
-
-        typer.echo(msg)
-    else:
-        return resp.output
-
-
-# TODO combine eval_resp and display_results
-def display_results(data: Union[List[dict], List[str]], tablefmt: str = "simple",
-                    pager=True, outfile: Path = None) -> Union[list, dict]:
-    outdata = utils.output(data, tablefmt)
-    typer.echo_via_pager(outdata) if pager and len(outdata) > tty.rows else typer.echo(outdata)
-
-    # -- // Output to file \\ --
-    if outfile and outdata:
-        if outfile.parent.resolve() == config.base_dir.resolve():
-            config.outdir.mkdir(exist_ok=True)
-            outfile = config.outdir / outfile
-
-        print(
-            typer.style(f"\nWriting output to {outfile}... ", fg="cyan"),
-            end=""
-        )
-        outfile.write_text(outdata.file)  # typer.unstyle(outdata) also works
-        typer.secho("Done", fg="green")
-
-
-show_help = ["all (devices)", "device[s] (same as 'all' unless followed by device identifier)", "switch[es]", "ap[s]",
-             "gateway[s]", "group[s]", "site[s]", "clients", "template[s]", "variables", "certs"]
 args_metavar_dev = "[name|ip|mac-address|serial]"
 args_metavar_site = "[name|site_id|address|city|state|zip]"
 args_metavar = f"""Optional Identifying Attribute: device: {args_metavar_dev} site: {args_metavar_site}"""
@@ -233,22 +58,22 @@ def template(operation: TemplateLevel1 = typer.Argument(...),
              version: str = typer.Option(None, metavar="<version>", help="[Templates] Filter by version"),
              model: str = typer.Option(None, metavar="<model>", help="[Templates] Filter by model"),
              debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                                        callback=debug_callback),
+                                        callback=cli.debug_callback),
+             default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                          callback=cli.default_callback),
              account: str = typer.Option("central_info",
                                          envvar="ARUBACLI_ACCOUNT",
                                          help="The Aruba Central Account to use (must be defined in the config)",
-                                         callback=account_name_callback),
+                                         callback=cli.account_name_callback),
              ) -> None:
+    """Add, Delete, Update a Template"""
 
-    # TODO cache template names
     if operation == "update":
         if what == "variable":
             if variable and value and device:
-                # ses = utils.spinner(SPIN_TXT_AUTH, CentralApi)
-                # cache = Cache(session)
-                device = cache.get_dev_identifier(device)
+                device = cli.cache.get_dev_identifier(device)
                 payload = {"variables": {variable: value}}
-                _resp = session.update_variables(device, payload)
+                _resp = cli.central.update_variables(device, payload)
                 if _resp:
                     log.info(f"Template Variable Updated {variable} -> {value}", show=False)
                     typer.echo(f"{typer.style('Success', fg=typer.colors.GREEN)}")
@@ -277,7 +102,7 @@ def template(operation: TemplateLevel1 = typer.Argument(...),
                 payload = utils.get_multiline_input("Paste in new template contents then press CTRL-D", typer.secho, fg="cyan")
                 payload = "\n".join(payload).encode()
 
-            _resp = session.update_existing_template(**kwargs, template=template, payload=payload)
+            _resp = cli.central.update_existing_template(**kwargs, template=template, payload=payload)
             if _resp:
                 log.info(f"Template {what} Updated {_resp.output}", show=False)
                 typer.secho(_resp.output, fg="green")
@@ -287,130 +112,24 @@ def template(operation: TemplateLevel1 = typer.Argument(...),
 
 
 @app.command()
-def add_vlan(group_dev: str = typer.Argument(...), pvid: str = typer.Argument(...), ip: str = typer.Argument(None),
-             mask: str = typer.Argument("255.255.255.0"), name: str = None, description: str = None,
-             interface: str = None, vrid: str = None, vrrp_ip: str = None, vrrp_pri: int = None):
-    cmds = []
-    cmds += [f"vlan {pvid}", "!"]
-    if name:
-        cmds += [f"vlan-name {name}", "!", f"vlan {name} {pvid}", "!"]
-    if ip:
-        _fallback_desc = f"VLAN{pvid}-SVI"
-        cmds += [f"interface vlan {pvid}", f"description {description or name or _fallback_desc}", f"ip address {ip} {mask}", "!"]
-    if vrid:
-        cmds += [f"vrrp {vrid}", f"ip address {vrrp_ip}", f"vlan {pvid}"]
-        if vrrp_pri:
-            cmds += [f"priority {vrrp_pri}"]
-        cmds += ["no shutdown", "!"]
-
-    # TODO move command gen to BuildCLI
-    caas.eval_caas_response(session.caasapi(group_dev, cmds))
-
-
-@app.command()
-def import_vlan(import_file: str = typer.Argument(config.stored_tasks_file),
-                key: str = None):
-    if import_file == config.stored_tasks_file and not key:
-        typer.echo("key is required when using the default import file")
-
-    data = utils.read_yaml(import_file)
-    if key:
-        data = data.get(key)
-
-    if data:
-        args = data.get("arguments", [])
-        kwargs = data.get("options", {})
-        add_vlan(*args, **kwargs)
-
-
-@app.command()
-def caas_batch(import_file: Path = typer.Argument(config.stored_tasks_file),
-               command: str = None, key: str = None):
-
-    if import_file == config.stored_tasks_file and not key:
-        typer.echo("key is required when using the default import file")
-        raise typer.Exit()
-
-    data = utils.read_yaml(import_file)
-    if key:
-        data = data.get(key)
-
-    if not data:
-        _msg = typer.style(f"{key} not found in {import_file}.  No Data to Process", fg=typer.colors.RED, bold=True)
-        typer.echo(_msg)
-    else:
-        args = data.get("arguments", [])
-        kwargs = data.get("options", {})
-        cmds = data.get("cmds", [])
-
-        if not args:
-            typer.secho("import data requires an argument specifying the group / device")
-            raise typer.Exit(1)
-
-        if command:
-            try:
-                exec(f"fn = {command}")
-                fn(*args, **kwargs)  # type: ignore # NoQA
-            except AttributeError:
-                typer.echo(f"{command} doesn't appear to be valid")
-        elif cmds:
-            kwargs = {**kwargs, **{"cli_cmds": cmds}}
-            resp = utils.spinner(SPIN_TXT_CMDS, session.caasapi, *args, **kwargs)
-            caas.eval_caas_response(resp)
-
-
-@app.command()
-def batch(
-    import_file: Path = typer.Argument(None, exists=True),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
-    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
-    account: str = typer.Option("central_info",
-                                envvar="ARUBACLI_ACCOUNT",
-                                help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
-    command: str = None, key: str = None
-) -> None:
-    """Perform batch operations using import data from file."""
-    data = config.get_file_data(import_file)
-
-    #
-    if import_file.sfx in ['.csv', '.tsv', '.dbf', '.xls', '.xlsx']:
-        # TODO do more than this quick and dirty data validation.
-        if data and len(data.headers) > 3:
-            data = [
-                {'site_name': i['site_name'], 'site_address': {k: v for k, v in i.items() if k != 'site_name'}} for i in data.dict
-            ]
-        else:
-            data = [
-                {'site_name': i['site_name'], 'geolocation': {k: v for k, v in i.items() if k != 'site_name'}} for i in data.dict
-            ]
-
-    # TODO move callback def to cli.py so methods in central.py are usable as module for other scripts
-    # without callback or with a different custom callback unrelated to centralcli
-    resp = session.request(session.create_site, site_list=data)
-    resp_data = eval_resp(resp)
-    display_results(resp_data)
-
-
-@app.command()
 def refresh(what: RefreshWhat = typer.Argument(...),
             debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                                       callback=debug_callback),
+                                       callback=cli.debug_callback),
+            default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                         callback=cli.default_callback),
             account: str = typer.Option("central_info",
                                         envvar="ARUBACLI_ACCOUNT",
                                         help="The Aruba Central Account to use (must be defined in the config)",
-                                        callback=account_name_callback),):
+                                        callback=cli.account_name_callback),):
     """refresh <'token'|'cache'>"""
 
-    session = CentralApi(account)
-    central = session.auth
+    central = CentralApi(account)
 
     if what.startswith("token"):
-        Response(central).refresh_token()
+        from centralcli.response import Session
+        Session(central.auth).refresh_token()
     else:  # cache is only other option
-        Cache(session=session, refresh=True)
+        cli.cache(central=cli.central, refresh=True)
 
 
 @app.command(hidden=True)
@@ -424,12 +143,14 @@ def method_test(method: str = typer.Argument(...),
                 outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
                 no_pager: bool = typer.Option(True, "--pager", help="Enable Paged Output"),
                 update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
+                default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                             callback=cli.default_callback),
                 debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                                           callback=debug_callback),
+                                           callback=cli.debug_callback),
                 account: str = typer.Option("central_info",
                                             envvar="ARUBACLI_ACCOUNT",
                                             help="The Aruba Central Account to use (must be defined in the config)",
-                                            callback=account_name_callback),
+                                            callback=cli.account_name_callback),
                 ) -> None:
     """dev testing commands to run CentralApi methods from command line
 
@@ -442,8 +163,8 @@ def method_test(method: str = typer.Argument(...),
 
     Displays all attributes of Response object
     """
-    session = CentralApi(account)
-    if not hasattr(session, method):
+    central = CentralApi(account)
+    if not hasattr(central, method):
         typer.secho(f"{method} does not exist", fg="red")
         raise typer.Exit(1)
     args = [k for k in kwargs if "=" not in k]
@@ -453,33 +174,24 @@ def method_test(method: str = typer.Argument(...),
 
     typer.secho(f"session.{method}({', '.join(a for a in args)}, "
                 f"{', '.join([f'{k}={kwargs[k]}' for k in kwargs]) if kwargs else ''})", fg="cyan")
-    resp = session.request(getattr(session, method), *args, **kwargs)
+    resp = central.request(getattr(central, method), *args, **kwargs)
 
     for k, v in resp.__dict__.items():
         if k != "output":
             if debug or not k.startswith("_"):
                 typer.echo(f"  {typer.style(k, fg='cyan')}: {v}")
 
-    data = eval_resp(resp, pad=2)
+    data = cli.eval_resp(resp, pad=2)
+    tablefmt = cli.get_format(
+        do_json, do_yaml, do_csv, do_rich,
+    )
 
+    typer.echo(f"\n{typer.style('CentralCLI Response Output', fg='cyan')}:")
+    cli.display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
+    data = asyncio.run(resp._response.json())
     if data:
-        if do_yaml is True:
-            tablefmt = "yaml"
-        elif do_csv is True:
-            tablefmt = "csv"
-        elif do_rich is True:
-            tablefmt = "rich"
-        elif do_table is True:
-            tablefmt = "simple"
-        else:
-            tablefmt = "json"
-
-        typer.echo(f"\n{typer.style('CentralCLI Response Output', fg='cyan')}:")
-        display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
-        data = asyncio.run(resp._response.json())
-        if data:
-            typer.echo(f"\n{typer.style('Raw Response Output', fg='cyan')}:")
-            display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
+        typer.echo(f"\n{typer.style('Raw Response Output', fg='cyan')}:")
+        cli.display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
 
 
 @app.callback()

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+from enum import Enum
+import sys
+import typer
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import config, log, utils, cli
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import config, log, utils, cli
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+tty = utils.tty
+app = typer.Typer()
+
+
+class BatchArgs(str, Enum):
+    sites = "sites"
+    # groups = "groups"
+
+
+@app.command()
+def add(
+    what: BatchArgs = typer.Argument(
+        ...,
+    ),
+    import_file: Path = typer.Argument(..., exists=True),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", callback=cli.default_callback),
+    debug: bool = typer.Option(
+        False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging", callback=cli.debug_callback
+    ),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        callback=cli.account_name_callback,
+    ),
+    command: str = None,
+    key: str = None,
+) -> None:
+    """Perform batch Add operations using import data from file."""
+    central = cli.central
+    data = config.get_file_data(import_file)
+
+    resp = None
+    if what == "sites":
+        if import_file.suffix in [".csv", ".tsv", ".dbf", ".xls", ".xlsx"]:
+            # TODO do more than this quick and dirty data validation.
+            if data and len(data.headers) > 3:  # address info
+                data = [
+                    {"site_name": i["site_name"], "site_address": {k: v for k, v in i.items() if k != "site_name"}}
+                    for i in data.dict
+                ]
+            else:  # geoloc
+                data = [
+                    {"site_name": i["site_name"], "geolocation": {k: v for k, v in i.items() if k != "site_name"}}
+                    for i in data.dict
+                ]
+
+        resp = central.request(central.create_site, site_list=data)
+
+    resp_data = cli.eval_resp(resp)
+    cli.display_results(resp_data)
+
+
+@app.callback()
+def callback():
+    """
+    Perform batch operations using data from import file.
+    """
+    pass
+
+
+log.debug(f'{__name__} called with Arguments: {" ".join(sys.argv)}')
+
+if __name__ == "__main__":
+    app()

--- a/centralcli/clicaas.py
+++ b/centralcli/clicaas.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import sys
+import typer
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import config, log, utils, caas
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import config, log, utils, caas
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+session = None
+tty = utils.tty
+app = typer.Typer()
+SPIN_TXT_CMDS = "Sending Commands to Aruba Central API Gateway..."
+
+
+@app.command()
+def bulk_edit(input_file: str = typer.Argument(None)):
+    cli = caas.BuildCLI(session=session, filename=input_file)
+    # TODO log cli
+    if cli.cmds:
+        for dev in cli.data:
+            group_dev = f"{cli.data[dev]['_common'].get('group')}/{dev}"
+            resp = session.caasapi(group_dev, cli.cmds)
+            caas.eval_caas_response(resp)
+
+
+@app.command()
+def add_vlan(group_dev: str = typer.Argument(...), pvid: str = typer.Argument(...), ip: str = typer.Argument(None),
+             mask: str = typer.Argument("255.255.255.0"), name: str = None, description: str = None,
+             interface: str = None, vrid: str = None, vrrp_ip: str = None, vrrp_pri: int = None):
+    cmds = []
+    cmds += [f"vlan {pvid}", "!"]
+    if name:
+        cmds += [f"vlan-name {name}", "!", f"vlan {name} {pvid}", "!"]
+    if ip:
+        _fallback_desc = f"VLAN{pvid}-SVI"
+        cmds += [f"interface vlan {pvid}", f"description {description or name or _fallback_desc}", f"ip address {ip} {mask}", "!"]
+    if vrid:
+        cmds += [f"vrrp {vrid}", f"ip address {vrrp_ip}", f"vlan {pvid}"]
+        if vrrp_pri:
+            cmds += [f"priority {vrrp_pri}"]
+        cmds += ["no shutdown", "!"]
+
+    # TODO move command gen to BuildCLI
+    caas.eval_caas_response(session.caasapi(group_dev, cmds))
+
+
+@app.command()
+def import_vlan(import_file: str = typer.Argument(config.stored_tasks_file),
+                key: str = None):
+    if import_file == config.stored_tasks_file and not key:
+        typer.echo("key is required when using the default import file")
+
+    data = utils.read_yaml(import_file)
+    if key:
+        data = data.get(key)
+
+    if data:
+        args = data.get("arguments", [])
+        kwargs = data.get("options", {})
+        add_vlan(*args, **kwargs)
+
+
+@app.command()
+def caas_batch(import_file: Path = typer.Argument(config.stored_tasks_file),
+               command: str = None, key: str = None):
+
+    if import_file == config.stored_tasks_file and not key:
+        typer.echo("key is required when using the default import file")
+        raise typer.Exit()
+
+    data = utils.read_yaml(import_file)
+    if key:
+        data = data.get(key)
+
+    if not data:
+        _msg = typer.style(f"{key} not found in {import_file}.  No Data to Process", fg=typer.colors.RED, bold=True)
+        typer.echo(_msg)
+    else:
+        args = data.get("arguments", [])
+        kwargs = data.get("options", {})
+        cmds = data.get("cmds", [])
+
+        if not args:
+            typer.secho("import data requires an argument specifying the group / device")
+            raise typer.Exit(1)
+
+        if command:
+            try:
+                exec(f"fn = {command}")
+                fn(*args, **kwargs)  # type: ignore # NoQA
+            except AttributeError:
+                typer.echo(f"{command} doesn't appear to be valid")
+        elif cmds:
+            kwargs = {**kwargs, **{"cli_cmds": cmds}}
+            resp = utils.spinner(SPIN_TXT_CMDS, session.caasapi, *args, **kwargs)
+            caas.eval_caas_response(resp)
+
+
+@app.callback()
+def callback():
+    """
+    Interact with Aruba Central CAAS API
+    """
+    pass
+
+
+log.debug(f'{__name__} called with Arguments: {" ".join(sys.argv)}')
+
+if __name__ == "__main__":
+    app()

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import typer
+import time
+import sys
+import json
+from typing import List, Literal, Union, Any
+from pathlib import Path
+
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import config, log, utils, Cache, Response
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import config, log, utils, Cache, Response
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+from centralcli.central import CentralApi
+
+
+tty = utils.tty
+FormatType = Literal["json", "yaml", "csv", "rich", "simple"]
+MsgType = Literal["initial", "previous", "forgot", "will_forget", "previous_will_forget"]
+
+
+class CLICommon:
+    def __init__(self, account: str = "default"):
+        self.account = account
+        self.cache = None
+        self.central = None
+
+    class AcctMsg:
+        def __init__(self, account: str = None, msg: MsgType = None) -> None:
+            self.account = account
+            self.msg = msg
+
+        def __repr__(self) -> str:
+            return str(self)
+
+        def __str__(self) -> str:
+            if self.msg and hasattr(self, self.msg):
+                return getattr(self, self.msg)
+            else:
+                return self.initial
+
+        @property
+        def initial(self):
+            acct_clr = f"{typer.style(self.account, fg='cyan')}"
+            return (
+                f"{typer.style(f'Using Account: {acct_clr}.', fg='magenta')}  "
+                f"{typer.style(f'Account setting is sticky.  ', fg='red', blink=True)}"
+                f"\n  {acct_clr} {typer.style(f'will be used for subsequent commands until', fg='magenta')}"
+                f"\n  {typer.style('--account <account name> or `-d` (revert to default). is used.', fg='magenta')}"
+            )
+
+        @property
+        def previous(self):
+            return (
+                f"{typer.style(f'Using previously specified account: ', fg='magenta')}"
+                f"{typer.style(self.account, fg='cyan', blink=True)}.  "
+                f"\n{typer.style('Use `--account <account name>` to switch to another account.', fg='magenta')}"
+                f"\n{typer.style('    or `-d` flag to revert to default account.', fg='magenta')}"
+            )
+
+        @property
+        def forgot(self):
+            return typer.style(
+                "Forget option set for account, and expiration has passed.  reverting to default account", fg="magenta"
+            )
+
+        @property
+        def will_forget(self):
+            return typer.style(
+                f"Forget options is configured, will revert to default account "
+                f'{typer.style(f"{config.forget_account_after} mins", fg="cyan")}'
+                f'{typer.style(" after last command.", fg="magenta")}',
+                fg="magenta",
+            )
+
+        @property
+        def previous_will_forget(self):
+            return f"{self.previous}\n\n{self.will_forget}"
+
+    def account_name_callback(self, ctx: typer.Context, account: str):
+        if ctx.resilient_parsing:  # tab completion, return without validating
+            return account
+
+        # -- // sticky last account caching and messaging \\ --
+        if account == "central_info":
+            if config.sticky_account_file.is_file():
+                last_account, last_cmd_ts = config.sticky_account_file.read_text().split("\n")
+                last_cmd_ts = float(last_cmd_ts)
+
+                # delete last_account file if they've configured forget_account_after
+                if config.forget_account_after:
+                    if time.time() > last_cmd_ts + (config.forget_account_after * 60):
+                        config.sticky_account_file.unlink(missing_ok=True)
+                        typer.echo(self.AcctMsg(msg="forgot"))
+                    else:
+                        account = last_account
+                        typer.echo(self.AcctMsg(account, msg="previous_will_forget"))
+                else:
+                    account = last_account
+                    typer.echo(self.AcctMsg(account, msg="previous"))
+        else:
+            if account in config.data:
+                config.sticky_account_file.write_text(f"{account}\n{round(time.time(), 2)}")
+                typer.echo(self.AcctMsg(account))
+
+        if account in config.data:
+            config.account = self.account = account
+            # global session
+            self.central = CentralApi(account)
+            # global cache
+            self.cache = Cache(self.central)
+            return account
+        else:
+            strip_keys = ["central_info", "ssl_verify", "token_store", "forget_account_after", "debug", "debugv", "limit"]
+            typer.echo(
+                f"{typer.style('ERROR:', fg=typer.colors.RED)} "
+                f"The specified account: '{account}' is not defined in the config @\n"
+                f"{config.file}\n\n"
+            )
+
+            _accounts = [k for k in config.data.keys() if k not in strip_keys]
+            if _accounts:
+                typer.echo(
+                    f"The following accounts are defined {_accounts}\n"
+                    f"The default account 'central_info' is used if no account is specified via --account flag.\n"
+                    f"or the ARUBACLI_ACCOUNT environment variable.\n"
+                )
+            else:
+                if not config.data:
+                    # TODO prompt user for details
+                    typer.secho("Configuration doesn't exist", fg="red")
+                else:
+                    typer.secho("No accounts defined in config", fg="red")
+
+            if account != "central_info" and "central_info" not in config.data:
+                typer.echo(
+                    f"{typer.style('WARNING:', fg='yellow')} "
+                    f"'central_info' is not defined in the config.  This is the default when not overriden by\n"
+                    f"--account parameter or ARUBACLI_ACCOUNT environment variable."
+                )
+
+            raise typer.Exit(code=1)
+
+    def default_callback(self, ctx: typer.Context, default: bool):
+        if ctx.resilient_parsing:  # tab completion, return without validating
+            return
+
+        if default and config.sticky_account_file.is_file():
+            typer.secho("Using default central account", fg="cyan")
+            config.sticky_account_file.unlink()
+
+    @staticmethod
+    def debug_callback(debug: bool):
+        if debug:
+            log.DEBUG = config.debug = debug
+
+    @staticmethod
+    def get_format(
+        do_json: bool = False, do_yaml: bool = False, do_csv: bool = False, do_rich: bool = False, default: str = "simple"
+    ) -> FormatType:
+        """Simple helper method to return the selected output format type (str)"""
+        if do_json:
+            return "json"
+        elif do_yaml:
+            return "yaml"
+        elif do_csv:
+            return "csv"
+        elif do_rich:
+            return "rich" if default == "simple" else "simple"
+        else:
+            return default
+
+    @staticmethod
+    def eval_resp(resp: Response, pad: int = 0, sort_by: str = None) -> Any:
+        if not resp.ok:
+            msg = f"{' ' * pad}{typer.style('ERROR:', fg=typer.colors.RED)} "
+            if isinstance(resp.output, dict):
+                _msg = resp.output.get("description", resp.output.get("detail", "")).replace("Error: ", "")
+                if _msg:
+                    msg += _msg
+                else:
+                    msg += json.dumps(resp.output)
+            else:
+                msg += str(resp.output)
+
+            typer.echo(msg)
+        else:
+            # TODO sort output
+            if sort_by is not None:
+                typer.secho("sort option not implemented yet", fg="red")
+
+            return resp.output
+
+    # TODO combine eval_resp and display_results
+    # TODO cleaner moves here (for now), then eventually to an output object (in utils now)
+    #   prep for breaking API into separate package.
+
+    @staticmethod
+    def display_results(
+        data: Union[List[dict], List[str], None],
+        tablefmt: str = "simple",
+        pager=True,
+        outfile: Path = None,
+        cleaner: callable = None,
+        **cleaner_kwargs,
+    ) -> None:
+        """Output Formatted API Response to display and optionally to file
+
+        Args:
+            data (Union[List[dict], List[str], None]): API Response Data.
+            tablefmt (str, optional): Format of output. Defaults to "simple" (tabular).
+            pager (bool, optional): Page Output / or not. Defaults to True.
+            outfile (Path, optional): path/file of output file. Defaults to None.
+            cleaner (callable, optional): The Cleaner function to use.
+        """
+        if data:
+            if cleaner:
+                data = cleaner(data, **cleaner_kwargs)
+
+            outdata = utils.output(data, tablefmt)
+            typer.echo_via_pager(outdata) if tty and pager and len(outdata) > tty.rows else typer.echo(outdata)
+
+            # -- // Output to file \\ --
+            if outfile and outdata:
+                if Path.joinpath(outfile.parent.resolve() / ".git").is_dir():
+                    config.outdir.mkdir(exist_ok=True)
+                    outfile = config.outdir / outfile
+
+                print(typer.style(f"\nWriting output to {outfile}... ", fg="cyan"), end="")
+                outfile.write_text(outdata.file)  # typer.unstyle(outdata) also works
+                typer.secho("Done", fg="green")
+
+
+if __name__ == "__main__":
+    pass

--- a/centralcli/clido.py
+++ b/centralcli/clido.py
@@ -1,26 +1,24 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import time
 from pathlib import Path
-from typing import Any, List, Union
+from typing import List
 import sys
 import typer
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import config, log, utils, Cache, Response
+    from centralcli import log, utils, cli
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import config, log, utils, Cache, Response
+        from centralcli import log, utils, cli
     else:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.central import CentralApi
-from centralcli.constants import (BlinkArgs, BounceArgs, arg_to_what)
+from centralcli.constants import (BlinkArgs, BounceArgs, arg_to_what) # noqa
 
 
 SPIN_TXT_AUTH = "Establishing Session with Aruba Central API Gateway..."
@@ -31,174 +29,6 @@ tty = utils.tty
 app = typer.Typer()
 
 
-class AcctMsg:
-    def __init__(self, account: str = None, msg: str = None) -> None:
-        self.account = account
-        self.msg = msg
-
-    def __repr__(self) -> str:
-        return str(self)
-
-    def __str__(self) -> str:
-        if self.msg and hasattr(self, self.msg):
-            return getattr(self, self.msg)
-        else:
-            return self.initial
-
-    @property
-    def initial(self):
-        acct_clr = f"{typer.style(self.account, fg='cyan')}"
-        return (
-            f"{typer.style(f'Using Account: {acct_clr}.', fg='magenta')}  "
-            f"{typer.style(f'Account setting is sticky.  ', fg='red', blink=True)}"
-            f"\n  {acct_clr} {typer.style(f'will be used for subsequent commands until', fg='magenta')}"
-            f"\n  {typer.style('--account <account name> or `-d` (revert to default). is used.', fg='magenta')}"
-        )
-
-    @property
-    def previous(self):
-        return (
-            f"{typer.style(f'Using previously specified account: ', fg='magenta')}"
-            f"{typer.style(self.account, fg='cyan', blink=True)}.  "
-            f"\n{typer.style('Use `--account <account name>` to switch to another account.', fg='magenta')}"
-            f"\n{typer.style('    or `-d` flag to revert to default account.', fg='magenta')}"
-        )
-
-    @property
-    def forgot(self):
-        typer.style(
-            "Forget option set for account, and expiration has passed.  reverting to default account",
-            fg="magenta"
-        )
-
-    @property
-    def will_forget(self):
-        return typer.style(
-            f'Forget options is configured, will revert to default account '
-            f'{typer.style(f"{config.forget_account_after} mins", fg="cyan")}'
-            f'{typer.style(" after last command.", fg="magenta")}',
-            fg="magenta"
-        )
-
-    @property
-    def previous_will_forget(self):
-        return f'{self.previous}\n\n{self.will_forget}'
-
-
-def default_callback(ctx: typer.Context, default: bool):
-    if ctx.resilient_parsing:  # tab completion, return without validating
-        return
-
-    if default and config.sticky_account_file.is_file():
-        typer.secho('Using default central account', fg="cyan")
-        config.sticky_account_file.unlink()
-
-
-# TODO ?? make more sense to have this return the ArubaCentralBase object ??
-def account_name_callback(ctx: typer.Context, account: str):
-    '''
-    Allows easy switching between configured central accounts.
-
-    Setting is sticky, only has to be set once, then that account will be used
-    until another account is specified via --account or -d flag is used to revert
-    back to default.
-    '''
-    if ctx.resilient_parsing:  # tab completion, return without validating
-        return account
-
-    # -- // sticky last account caching and messaging \\ --
-    if account == "central_info":
-        if config.sticky_account_file.is_file():
-            last_account, last_cmd_ts = config.sticky_account_file.read_text().split('\n')
-            last_cmd_ts = float(last_cmd_ts)
-
-            # delete last_account file if they've configured forget_account_after
-            if config.forget_account_after:
-                if time.time() > last_cmd_ts + (config.forget_account_after * 60):
-                    config.sticky_account_file.unlink(missing_ok=True)
-                    typer.echo(AcctMsg(msg="forgot"))
-                else:
-                    account = last_account
-                    typer.echo(AcctMsg(account, msg='previous_will_forget'))
-            else:
-                account = last_account
-                typer.echo(AcctMsg(account, msg='previous'))
-    else:
-        if account in config.data:
-            config.sticky_account_file.write_text(f'{account}\n{round(time.time(), 2)}')
-            typer.echo(AcctMsg(account))
-
-    if account in config.data:
-        config.account = account
-        global session
-        session = CentralApi(account)
-        global cache
-        cache = Cache(session)
-        return account
-    else:
-        strip_keys = ['central_info', 'ssl_verify', 'token_store', 'forget_account_after', 'debug', 'debugv', 'limit']
-        typer.echo(f"{typer.style('ERROR:', fg=typer.colors.RED)} "
-                   f"The specified account: '{account}' is not defined in the config @\n"
-                   f"{config.file}\n\n")
-
-        _accounts = [k for k in config.data.keys() if k not in strip_keys]
-        if _accounts:
-            typer.echo(f"The following accounts are defined {_accounts}\n"
-                       f"The default account 'central_info' is used if no account is specified via --account flag.\n"
-                       f"or the ARUBACLI_ACCOUNT environment variable.\n")
-        else:
-            if not config.data:
-                # TODO prompt user for details
-                typer.secho("Configuration doesn't exist", fg="red")
-            else:
-                typer.secho("No accounts defined in config", fg="red")
-
-        if account != "central_info" and "central_info" not in config.data:
-            typer.echo(f"{typer.style('WARNING:', fg='yellow')} "
-                       f"'central_info' is not defined in the config.  This is the default when not overriden by\n"
-                       f"--account parameter or ARUBACLI_ACCOUNT environment variable.")
-
-        raise typer.Exit(code=1)
-
-
-def debug_callback(debug: bool):
-    if debug:
-        log.DEBUG = config.debug = debug
-
-
-def eval_resp(resp: Response, pad: int = 0) -> Any:
-    if not resp.ok:
-        msg = f"{' ' * pad}{typer.style('ERROR:', fg=typer.colors.RED)} "
-        if isinstance(resp.output, dict):
-            msg += f"{resp.output.get('description', resp.error).replace('Error: ', '')}"
-        else:
-            msg += str(resp.output)
-
-        typer.echo(msg)
-    else:
-        return resp.output
-
-
-# TODO combine eval_resp and display_results
-def display_results(data: Union[List[dict], List[str]], tablefmt: str = "simple",
-                    pager=True, outfile: Path = None) -> Union[list, dict]:
-    outdata = utils.output(data, tablefmt)
-    typer.echo_via_pager(outdata) if pager and len(outdata) > tty.rows else typer.echo(outdata)
-
-    # -- // Output to file \\ --
-    if outfile and outdata:
-        if outfile.parent.resolve() == config.base_dir.resolve():
-            config.outdir.mkdir(exist_ok=True)
-            outfile = config.outdir / outfile
-
-        print(
-            typer.style(f"\nWriting output to {outfile}... ", fg="cyan"),
-            end=""
-        )
-        outfile.write_text(outdata.file)  # typer.unstyle(outdata) also works
-        typer.secho("Done", fg="green")
-
-
 @app.command(short_help="Bounce Interface or PoE on Interface")
 def bounce(
     what: BounceArgs = typer.Argument(...),
@@ -207,24 +37,24 @@ def bounce(
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
     yes = yes_ if yes_ else yes
-    serial = cache.get_dev_identifier(device)
+    serial = cli.cache.get_dev_identifier(device)
     command = 'bounce_poe_port' if what == 'poe' else 'bounce_interface'
-    if yes or typer.confirm(typer.style(f"Please Confirm {what} {device} {port}", fg="cyan")):
-        resp = session.request(session.send_bounce_command_to_device, serial, command, port)
+    if yes or typer.confirm(typer.style(f"Please Confirm bounce {what} on {device} port {port}", fg="cyan")):
+        resp = cli.central.request(cli.central.send_bounce_command_to_device, serial, command, port)
         typer.secho(str(resp), fg="green" if resp else "red")
         # !! removing this for now Central ALWAYS returns:
         # !!   reason: Sending command to device. state: QUEUED, even after command execution.
         # if resp and resp.get('task_id'):
-        #     resp = session.request(session.get_task_status, resp.task_id)
+        #     resp = cli.central.request(session.get_task_status, resp.task_id)
         #     typer.secho(str(resp), fg="green" if resp else "red")
 
     else:
@@ -237,19 +67,19 @@ def reboot(
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
     yes = yes_ if yes_ else yes
-    serial = cache.get_dev_identifier(device)
+    serial = cli.cache.get_dev_identifier(device)
     reboot_msg = f"{typer.style('*reboot*', fg='red')} {typer.style(f'{device}', fg='cyan')}"
     if yes or typer.confirm(typer.style(f"Please Confirm: {reboot_msg}", fg="cyan")):
-        resp = session.request(session.send_command_to_device, serial, 'reboot')
+        resp = cli.central.request(cli.central.send_command_to_device, serial, 'reboot')
         typer.secho(str(resp), fg="green" if resp else "red")
     else:
         raise typer.Abort()
@@ -263,18 +93,18 @@ def blink(
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
     yes = yes_ if yes_ else yes
     command = f'blink_led_{action}'
-    serial = cache.get_dev_identifier(device)
-    resp = session.request(session.send_command_to_device, serial, command, duration=secs)
+    serial = cli.cache.get_dev_identifier(device)
+    resp = cli.central.request(cli.central.send_command_to_device, serial, command, duration=secs)
     typer.secho(str(resp), fg="green" if resp else "red")
 
 
@@ -284,19 +114,19 @@ def nuke(
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
     yes = yes_ if yes_ else yes
-    serial = cache.get_dev_identifier(device)
+    serial = cli.cache.get_dev_identifier(device)
     nuke_msg = f"{typer.style('*Factory Default*', fg='red')} {typer.style(f'{device}', fg='cyan')}"
     if yes or typer.confirm(typer.style(f"Please Confirm: {nuke_msg}", fg="cyan")):
-        resp = session.request(session.send_command_to_device, serial, 'erase_configuration')
+        resp = cli.central.request(cli.central.send_command_to_device, serial, 'erase_configuration')
         typer.secho(str(resp), fg="green" if resp else "red")
     else:
         raise typer.Abort()
@@ -306,16 +136,16 @@ def nuke(
 def save(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
-    serial = cache.get_dev_identifier(device)
-    resp = session.request(session.send_command_to_device, serial, 'save_configuration')
+    serial = cli.cache.get_dev_identifier(device)
+    resp = cli.central.request(cli.central.send_command_to_device, serial, 'save_configuration')
     typer.secho(str(resp), fg="green" if resp else "red")
 
 
@@ -323,16 +153,16 @@ def save(
 def sync(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
-    serial = cache.get_dev_identifier(device)
-    resp = session.request(session.send_command_to_device, serial, 'config_sync')
+    serial = cli.cache.get_dev_identifier(device)
+    resp = cli.central.request(cli.central.send_command_to_device, serial, 'config_sync')
     typer.secho(str(resp), fg="green" if resp else "red")
 
 
@@ -341,15 +171,15 @@ def update_vars(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     var_value: List[str] = typer.Argument(..., help="comma seperated list 'variable = value, variable2 = value2'"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
-    serial = cache.get_dev_identifier(device)
+    serial = cli.cache.get_dev_identifier(device)
     vars, vals, get_next = [], [], False
     for var in var_value:
         if var == '=':
@@ -376,7 +206,7 @@ def update_vars(
     typer.secho(f"Please Confirm: Update {device}", fg="cyan")
     [typer.echo(f'    {k}: {v}') for k, v in var_dict.items()]
     if typer.confirm(typer.style("Proceed with these values", fg="cyan")):
-        resp = session.request(session.update_variables, serial, **var_dict)
+        resp = cli.central.request(cli.central.update_variables, serial, **var_dict)
         typer.secho(str(resp), fg="green" if resp else "red")
 
 
@@ -387,19 +217,19 @@ def move(
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
     yes = yes_ if yes_ else yes
-    serial = cache.get_dev_identifier(device)
-    group = cache.get_group_identifier(group)
+    serial = cli.cache.get_dev_identifier(device)
+    group = cli.cache.get_group_identifier(group)
     if yes or typer.confirm(typer.style(f"Please Confirm: move {device} to group {group}", fg="cyan")):
-        resp = session.request(session.move_dev_to_group, group, serial)
+        resp = cli.central.request(cli.central.move_dev_to_group, group, serial)
         typer.secho(str(resp), fg="green" if resp else "red")
     else:
         raise typer.Abort()
@@ -409,16 +239,16 @@ def move(
 def kick(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
-                               callback=debug_callback),
+                               callback=cli.debug_callback),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                 callback=default_callback),
+                                 callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=account_name_callback),
+                                callback=cli.account_name_callback),
 ) -> None:
-    serial = cache.get_dev_identifier(device)
-    resp = session.request(session.send_command_to_device, serial, 'save_configuration')
+    serial = cli.cache.get_dev_identifier(device)
+    resp = cli.central.request(cli.central.send_command_to_device, serial, 'save_configuration')
     typer.secho(str(resp), fg="green" if resp else "red")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.4a17"
+version = "0.4a18"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
refactor some name-spaces, create clicommon w/ CLICommon object...

CentralApi where all the actual API calls are... chgd from session -> central
ArubaCentralBase goes session.central -> central.auth
Both of the above should be derived from the new CLICommon class available as `cli` from __init__

cli.central:  Where all the API methods live
cli.central.auth:  ArubaCentralBase class
cli.cache common cache object now available to all files (just import cli)
callbacks and output methods are all under cli
cli.account_name_callback, cli.eval_resp...