### PR TITLE
batch ap rename + support multiple requests/responses...

### DIFF
--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -123,6 +123,7 @@ def pre_clean(data: dict) -> dict:
     return data
 
 
+# TODO moved to utils
 def _unlist(data: Any):
     """Remove unnecessary outer lists.
 

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import asyncio
 import sys
 from pathlib import Path
 from typing import List
@@ -113,17 +112,15 @@ def method_test(method: str = typer.Argument(...),
             if debug or not k.startswith("_"):
                 typer.echo(f"  {typer.style(k, fg='cyan')}: {v}")
 
-    data = cli.eval_resp(resp, pad=2)
+    # data = cli.eval_resp(resp, pad=2)
     tablefmt = cli.get_format(
         do_json, do_yaml, do_csv, do_table
     )
 
     typer.echo(f"\n{typer.style('CentralCLI Response Output', fg='cyan')}:")
-    cli.display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
-    data = asyncio.run(resp._response.json())
-    if data:
-        typer.echo(f"\n{typer.style('Raw Response Output', fg='cyan')}:")
-        cli.display_results(data, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
+    cli.display_results(resp, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
+    typer.echo(f"\n{typer.style('Raw Response Output', fg='cyan')}:")
+    cli.display_results(data=resp.raw, tablefmt=tablefmt, pager=not no_pager, outfile=outfile)
 
 
 @app.callback()

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -8,12 +8,12 @@ import typer
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import config, log, utils, cli
+    from centralcli import config, log, utils, cli, Response
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import config, log, utils, cli
+        from centralcli import config, log, utils, cli, Response
     else:
         print(pkg_dir.parts)
         raise e
@@ -24,14 +24,16 @@ app = typer.Typer()
 
 class BatchArgs(str, Enum):
     sites = "sites"
-    # groups = "groups"
+    aps = "aps"
+
+
+def do_lldp_rename(fstr: str) -> Response:
+    pass
 
 
 @app.command()
 def add(
-    what: BatchArgs = typer.Argument(
-        ...,
-    ),
+    what: BatchArgs = typer.Argument(...,),
     import_file: Path = typer.Argument(..., exists=True),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", callback=cli.default_callback),
     debug: bool = typer.Option(
@@ -51,15 +53,21 @@ def add(
     resp = None
     if what == "sites":
         if import_file.suffix in [".csv", ".tsv", ".dbf", ".xls", ".xlsx"]:
-            # TODO do more than this quick and dirty data validation.
-            if data and len(data.headers) > 3:  # address info
+            # TODO Exception handler
+            if "address" in str(data.headers) and len(data.headers) > 3:  # address info
                 data = [
-                    {"site_name": i["site_name"], "site_address": {k: v for k, v in i.items() if k != "site_name"}}
+                    {
+                        "site_name": i.get("site_name", i.get("site", "ERROR")),
+                        "site_address": {k: v for k, v in i.items() if k not in ["site", "site_name"]}
+                    }
                     for i in data.dict
                 ]
             else:  # geoloc
                 data = [
-                    {"site_name": i["site_name"], "geolocation": {k: v for k, v in i.items() if k != "site_name"}}
+                    {
+                        "site_name": i.get("site_name", i.get("site", "ERROR")),
+                        "geolocation": {k: v for k, v in i.items() if k not in ["site", "site_name"]}
+                    }
                     for i in data.dict
                 ]
 
@@ -69,10 +77,81 @@ def add(
     cli.display_results(resp_data)
 
 
+@app.command()
+def rename(
+    what: BatchArgs = typer.Argument(...,),
+    import_file: Path = typer.Argument(None, exists=True),
+    lldp: bool = typer.Option(None, help="Automatic AP rename based on lldp info from upstream switch.",),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", callback=cli.default_callback),
+    debug: bool = typer.Option(
+        False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging", callback=cli.debug_callback
+    ),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        callback=cli.account_name_callback,
+    ),
+) -> None:
+    """Perform AP rename in batch from import file or automatically based on LLDP"""
+    central = cli.central
+    if import_file:
+        data = config.get_file_data(import_file)
+
+        resp = None
+        if what == "aps":
+            if import_file.suffix in [".csv", ".tsv", ".dbf", ".xls", ".xlsx"]:
+                if data and len(data.headers) < 3:
+                    if "name" in data.headers:
+                        data = [{k if k != "name" else "hostname": d[k] for k in d} for d in data.dict]
+                        data.headers["hostname"] = data.headers.pop(
+                            data.headers.index(data.headers["name"])
+                        )
+                    data = {
+                        i.get("serial", i.get("serial_number", i.get("serial_num", "ERROR"))):
+                        {k: v for k, v in i.items() if not k.startswith("serial")} for i in data.dict
+                    }
+            calls = []
+            for ap in data:
+                calls.append(central.BatchRequest(central.update_ap_settings, (ap,), data[ap]))
+
+            resp = central.batch_request(calls)
+
+    elif lldp:
+        rtxt = typer.style("RESULT: ", fg=typer.colors.BRIGHT_BLUE)
+        typer.secho("Rename APs based on LLDP:", fg="bright_green")
+        typer.echo(
+            "This function will automatically rename APs based on a combination of\n"
+            "information from the upstream switch (via LLDP) and from the AP itself.\n\n"
+            "Please provide a format string based on these examples:\n"
+            "  For the examples: hostname 'SNANTX-IDF3-sw1, AP on port 7\n"
+            "                    AP mac aa:bb:cc:dd:ee:ff\n"
+            f"{typer.style('Format String Examples:', fg='cyan')}\n"
+            "  Upstream switches hostname: \n"
+            "      '%h[1:4]%'    will use the first 3 characters of the switches hostname.\n"
+            f"         {rtxt} 'SNAN'\n"
+            "      '%H-1%'    will split the hostname into parts separating on '-' and use\n"
+            f"         the firt segment.  {rtxt} 'SNANTX\n"
+            f"      '%p%'    represents the interface.  {rtxt} '7'\n"
+            "                   note: an interface in the form 1/1/12 is converted to 1_1_12\n"
+            "       '%p/3%    seperates the port string on / and uses the 3rd segment.\n"
+            "        '%m% or %m[-4] = last 4 digits of the AP MAC\n"
+            "        '%m:1% would split on : and take the 1st segment.\n"
+        )
+        fstr = typer.prompt("Enter Desired format string:")
+        do_lldp_rename(fstr)
+    else:
+        typer.secho("import file Argument is required if --lldp flag not provided", fg="red")
+
+    cli.display_results(resp)
+
+
 @app.callback()
 def callback():
     """
-    Perform batch operations using data from import file.
+    Perform batch operations.
     """
     pass
 

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -20,6 +20,7 @@ STRIP_KEYS = [
     "vlans",
     "result",
     "networks",
+    "ports",
 ]
 
 
@@ -95,6 +96,10 @@ class KickArgs(str, Enum):
     all = "all"
     mac = "mac"
     wlan = "wlan"
+
+
+class BatchApArgs(str, Enum):
+    rename = "rename"
 
 
 # Used to determine if arg is for a device (vs group, templates, ...)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'cencli Aruba Central API CLI'
+copyright = '2021, Wade Wells ~ Pack3tL0ss'
+author = 'Wade Wells ~ Pack3tL0ss'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. cencli Aruba Central API CLI documentation master file, created by
+   sphinx-quickstart on Fri Feb 19 03:15:54 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to cencli Aruba Central API CLI's documentation!
+========================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.4a19"
+version = "0.6a1"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
multi request support, multi response output support
multiple requests can be sent now.  It will run the first one (so token
can be handled if necessary) then the remainder in parallel.

display_response will accept a list of responses now.

Add `cli batch rename aps <path/file>`
and `cli batch rename aps --lldp` <- just started doesn't don anything yet.

collapse eval_resp into display_results...
Tweaks to output methods utils.output, clicommon.display_response

tweaks to cache