### PR TITLE
fix: auto rename based on lldp

### DIFF
--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -33,10 +33,15 @@ class BatchDelArgs(str, Enum):
 
 
 def do_lldp_rename(fstr: str) -> Response:
-    _all_aps = cli.central.request(cli.central.get_devices, "aps", status="Up")
+    resp = cli.central.request(cli.central.get_devices, "aps", status="Up")
+
+    if not resp:
+        typer.secho(resp)
+        raise typer.Exit(1)
+
     _keys = ["name", "mac", "model"]
-    _all_aps = utils.listify(_all_aps)
-    ap_dict = {d["serial"]: {k: d[k] for k in d.output if k in _keys} for d in _all_aps}
+    _all_aps = resp.output
+    ap_dict = {d["serial"]: {k: d[k] for k in d if k in _keys} for d in _all_aps}
     fstr_to_key = {
         "h": "neighborHostName",
         "m": "mac",

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -276,7 +276,7 @@ class CLICommon:
                 else:
                     # TODO add sort and reverse funcs
                     if sort_by is not None:
-                        typer.secho("sort option not implemented yet", fg="red")
+                        typer.secho("sort by is not implemented for all commands yet", fg="red")
 
                     self._display_results(
                         r.output,


### PR DESCRIPTION
Not sure how it was working before but it was.  I listify response
as if I was potentially expecting a list of Response objects.

But the command to get aps (line 36) is not a batch, so would only
expect a single Response (with a list of dicts in output attribute).

Need to add per site / per ap filters.