### PR TITLE
improve: batch rename APs

### DIFF
--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -56,6 +56,12 @@ from .response import Response
 from .clicommon import CLICommon
 cli = CLICommon()
 
+# if no environ vars set for LESS command line options
+# set -X to retain scrollback after quiting less
+#     -R for color output (default for the pager but defaults are not used if LESS is set)
+#     +G so (start with output scrolled to end) so scrollback contains all contents
+if not os.environ.get("LESS"):
+    os.environ["LESS"] = "-RX +G"
 
 if os.environ.get("TERM_PROGRAM") == "vscode":
     from .vscodeargs import vscode_arg_handler

--- a/centralcli/boilerplate/configuration.py
+++ b/centralcli/boilerplate/configuration.py
@@ -1987,7 +1987,6 @@ class AllCalls(CentralApi):
 
         return await self.patch(url, json_data=json_data)
 
-
     async def configuration_delete_wlan(self, group_name_or_guid: str, wlan_name: str) -> Response:
         """Delete an existing WLAN.
 

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -239,6 +239,7 @@ class CLICommon:
         reverse: bool = None,
         pad: int = None,
         cleaner: callable = None,
+        exit_on_fail: bool = False,
         **cleaner_kwargs,
     ) -> None:
         """Output Formatted API Response to display and optionally to file
@@ -273,6 +274,8 @@ class CLICommon:
                     typer.secho(f"Request {idx + 1} ({r.url.path}) Response:", fg="cyan")
                 if not r:
                     typer.secho(str(r), fg="green" if r else "red")
+                    if exit_on_fail:
+                        raise typer.Exit(1)
                 else:
                     # TODO add sort and reverse funcs
                     if sort_by is not None:

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -98,13 +98,32 @@ class Response:
         if isinstance(name, (str, int)) and hasattr(self, "output") and name in self.output:
             self.output[name] = value
 
+    def __len__(self):
+        return(len(self.output))
+
     def __getitem__(self, key):
         return self.output[key]
 
+    def __reversed__(self):
+        return self.output[::-1]
+
+    def __bytes__(self):
+        if not self.output:
+            return
+        r = json.dumps(self.output)
+        return r.encode("UTF-8")
+
     def __getattr__(self, name: str) -> Any:
         if hasattr(self, "output") and self.output:
-            if name in self.output:
-                return self.output[name]
+            if isinstance(self.output, list) and len(self.output) == 1:
+                output = self.output[0]
+
+                if name in output:
+                    return output[name]
+
+            # return the responses list / dict attr if exist
+            if hasattr(self.output, name):
+                return getattr(self.output, name)
 
         if hasattr(self._response, name):
             return getattr(self._response, name)
@@ -130,6 +149,7 @@ class Response:
 
     @property
     def status_code(self) -> int:
+        """Make attributes used for status code for both aiohttp and requests valid."""
         return self.status
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.7a9"
+version = "0.8a"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
Now handles int specifiers > 1 digit i.e. `%h[5:10]`
Add format string validation and error detection
w/ verbose messaging for detected errors.

Loop for retry if errors.

Still needs to be simplified, Readability a bit on the meh side, but
functional.