### PR TITLE
feature: Add `-v` option to show groups.

### DIFF
--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1688,6 +1688,10 @@ class CentralApi(Session):
         """
         url = "/configuration/v1/groups/properties"
 
+        # Central API method doesn't actually take a list it takes a string with
+        # group names separated by comma (NO SPACES)
+        groups = ",".join(utils.listify(groups))
+
         params = {
             'groups': groups
         }


### PR DESCRIPTION
`show groups -v` will add AoSVersion (8x/10x) and MonitorOnlySwitch
columns to output (additional API call to central to gather)