### PR TITLE
+ add / clone / delete group.  upgrade (firmware)

### DIFF
--- a/centralcli/boilerplate/firmware.py
+++ b/centralcli/boilerplate/firmware.py
@@ -2,7 +2,7 @@ import sys
 import asyncio
 import json
 from pathlib import Path
-from typing import Union, List
+from typing import Literal, Union, List
 
 
 # Detect if called from pypi installed package or via cloned github repo (development)
@@ -149,27 +149,28 @@ class AllCalls(CentralApi):
 
         return await self.get(url)
 
-    async def firmware_upgrade_firmware(self, firmware_scheduled_at: int, swarm_id: str,
-                                        serial: str, group: str, device_type: str,
-                                        firmware_version: str, reboot: bool, model: str) -> Response:
-        """Firmware Upgrade.
+    async def firmware_upgrade_firmware(
+        self, scheduled_at: int = None,
+        swarm_id: str = None,
+        serial: str = None,
+        group: str = None,
+        device_type: Literal["IAP", "MAS", "HP", "CONTROLLER"] = None,
+        firmware_version: str = None,
+        reboot: bool = False,
+        model: str = None
+    ) -> Response:
+        """Initiate firmware upgrade on device(s).
 
         Args:
-            firmware_scheduled_at (int): Firmware upgrade will be scheduled at,
-                firmware_scheduled_at - current time. firmware_scheduled_at is epoch in seconds and
-                default value is current time
-            swarm_id (str): Swarm ID
-            serial (str): Serial of device
-            group (str): Specify Group Name to initiate upgrade  for whole group.
-            device_type (str): Specify one of "IAP/MAS/HP/CONTROLLER"
-            firmware_version (str): Specify firmware version to which you want device to upgrade. If
-                you do not specify this field then firmware upgrade initiated with recommended
-                firmware version
-            reboot (bool): Use True for auto reboot after successful firmware download. Default
-                value is False. Applicable only on MAS, aruba switches and controller since IAP
-                reboots automatically after firmware download.
-            model (str): To initiate upgrade at group level for specific model family. Applicable
-                only for Aruba switches.
+            scheduled_at (int, optional): When to schedule upgrade (epoch seconds). Defaults to None (Now).
+            swarm_id (str, optional): Upgrade a specific swarm by id. Defaults to None.
+            serial (str, optional): Upgrade a specific device by serial. Defaults to None.
+            group (str, optional): Upgrade devices belonging to group. Defaults to None.
+            device_type (str["IAP"|"MAS"|"HP"|"CONTROLLER"]): Type of device to upgrade. Defaults to None.
+            firmware_version (str, optional): Version to upgrade to. Defaults to None(recommended version).
+            reboot (bool, optional): Automatically reboot device after firmware download. Defaults to False.
+            model (str, optional): To initiate upgrade at group level for specific model family. Applicable
+                only for Aruba switches. Defaults to None.
 
         Returns:
             Response: CentralAPI Response object
@@ -177,7 +178,7 @@ class AllCalls(CentralApi):
         url = "/firmware/v1/upgrade"
 
         json_data = {
-            'firmware_scheduled_at': firmware_scheduled_at,
+            'firmware_scheduled_at': scheduled_at,
             'swarm_id': swarm_id,
             'serial': serial,
             'group': group,

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -9,12 +9,12 @@ import typer
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import clibatch, clicaas, clido, clishow, clidel, cliadd, cliupdate, cli, log, utils
+    from centralcli import clibatch, clicaas, clido, clishow, clidel, cliadd, cliupdate, cliupgrade, cliclone, cli, log, utils
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import (clibatch, clicaas, clido, clishow, clidel, cliadd, cliupdate, cli, log,
+        from centralcli import (clibatch, clicaas, clido, clishow, clidel, cliadd, cliupdate, cliupgrade, cliclone, cli, log,
                                 utils)
     else:
         print(pkg_dir.parts)
@@ -35,7 +35,9 @@ app.add_typer(clishow.app, name="show")
 app.add_typer(clido.app, name="do", )
 app.add_typer(clidel.app, name="delete")
 app.add_typer(cliadd.app, name="add")
+app.add_typer(cliclone.app, name="clone")
 app.add_typer(cliupdate.app, name="update")
+app.add_typer(cliupgrade.app, name="upgrade")
 app.add_typer(clibatch.app, name="batch")
 app.add_typer(clicaas.app, name="caas", hidden=True)
 
@@ -50,7 +52,7 @@ def refresh(what: RefreshWhat = typer.Argument(...),
             debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                        callback=cli.debug_callback),
             default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
-                                         callback=cli.default_callback),
+                                         callback=cli.default_callback), show_default=False,
             account: str = typer.Option("central_info",
                                         envvar="ARUBACLI_ACCOUNT",
                                         help="The Aruba Central Account to use (must be defined in the config)",
@@ -76,7 +78,7 @@ def method_test(method: str = typer.Argument(...),
                 outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True),
                 no_pager: bool = typer.Option(True, "--pager", help="Enable Paged Output"),
                 update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
-                default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                              callback=cli.default_callback),
                 debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                            callback=cli.debug_callback),

--- a/centralcli/cliclone.py
+++ b/centralcli/cliclone.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+import sys
+import typer
+
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import cli
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import cli
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+app = typer.Typer()
+
+
+@app.command(short_help="Clone a group")
+def group(
+    clone_group: str = typer.Argument(..., metavar="[NAME OF GROUP TO CLONE]"),
+    new_group: str = typer.Argument(..., metavar="[NAME OF GROUP TO CREATE]"),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
+                               callback=cli.debug_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
+                                 callback=cli.default_callback),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                callback=cli.account_name_callback),
+) -> None:
+    yes = yes_ if yes_ else yes
+
+    _msg = f'{typer.style(f"Clone group", fg="cyan")}'
+    _msg = f'{_msg} {typer.style(clone_group, fg="bright_green")}'
+    _msg = f'{_msg} {typer.style("to new group", fg="cyan")}'
+    _msg = f'{_msg} {typer.style(new_group, fg="bright_green")}'
+    _msg = f'{_msg}{typer.style("?", fg="cyan")}'
+
+    if yes or typer.confirm(_msg):
+        resp = cli.central.request(cli.central.clone_group, clone_group, new_group)
+        cli.display_results(resp)
+
+
+@app.callback()
+def callback():
+    """
+    Clone Aruba Central Groups
+    """
+    pass
+
+
+if __name__ == "__main__":
+    print("hit")
+    app()

--- a/centralcli/clidel.py
+++ b/centralcli/clidel.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 import sys
+from typing import List
 import typer
 
 # Detect if called from pypi installed package or via cloned github repo (development)
@@ -17,8 +18,6 @@ except (ImportError, ModuleNotFoundError) as e:
         print(pkg_dir.parts)
         raise e
 
-# from centralcli.constants import IdenMetaVars
-
 app = typer.Typer()
 
 
@@ -29,7 +28,7 @@ def certificate(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -52,13 +51,14 @@ def site(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 callback=cli.account_name_callback),
 ) -> None:
+    yes = yes_ if yes_ else yes
     site = cli.cache.get_site_identifier(name)
     confirm_1 = typer.style("Please Confirm:", fg="cyan")
     confirm_2 = typer.style("Delete", fg="bright_red")
@@ -66,6 +66,35 @@ def site(
     if yes or typer.confirm(f"{confirm_1} {confirm_2} {confirm_3}"):
         resp = cli.central.request(cli.central.delete_site, site.id)
         typer.secho(str(resp), fg="green" if resp else "red")
+
+
+@app.command(short_help="Delete group(s)")
+def group(
+    groups: List[str] = typer.Argument(..., help="Group to delete (can provide more than one)."),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
+                               callback=cli.debug_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
+                                 callback=cli.default_callback),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                callback=cli.account_name_callback),
+) -> None:
+    yes = yes_ if yes_ else yes
+    groups = [cli.cache.get_group_identifier(g) for g in groups]
+    reqs = [cli.central.BatchRequest(cli.central.delete_group, (g.name, )) for g in groups]
+
+    _delim = typer.style(", ", fg="cyan")
+    confirm_1 = typer.style("Please Confirm:", fg="cyan")
+    confirm_2 = typer.style("Delete", fg="bright_red")
+    confirm_3 = typer.style("group" if len(groups) == 1 else "groups", fg="cyan")
+    confirm_4 = f'{_delim.join(typer.style(g.name, fg="bright_green") for g in groups)}{typer.style("?", fg="cyan")}'
+
+    if yes or typer.confirm(f"{confirm_1} {confirm_2} {confirm_3} {confirm_4}"):
+        resp = cli.central.batch_request(reqs)
+        cli.display_results(resp)
 
 
 @app.command(short_help="Delete a WLAN (SSID)")
@@ -76,13 +105,14 @@ def wlan(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 callback=cli.account_name_callback),
 ) -> None:
+    yes = yes_ if yes_ else yes
     group = cli.cache.get_group_identifier(group)
     confirm_1 = typer.style("Please Confirm:", fg="cyan")
     confirm_2 = typer.style("Delete", fg="bright_red")
@@ -101,10 +131,12 @@ def callback():
 
 
 if __name__ == "__main__":
+    app()
+else:
     if len(sys.argv) > 2 and sys.argv[1] == 'delete':
         if sys.argv[2] == "sites":
             sys.argv[2] = "site"
+        if sys.argv[2] == "groups":
+            sys.argv[2] = "group"
         elif sys.argv[2] in ["certificates", "certs", "cert"]:
             sys.argv[2] = "certificate"
-
-    app()

--- a/centralcli/clido.py
+++ b/centralcli/clido.py
@@ -18,7 +18,7 @@ except (ImportError, ModuleNotFoundError) as e:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.constants import (BlinkArgs, BounceArgs, KickArgs, RenameArgs, arg_to_what) # noqa
+from centralcli.constants import (BlinkArgs, BounceArgs, IdenMetaVars, KickArgs, RenameArgs, arg_to_what) # noqa
 
 
 SPIN_TXT_AUTH = "Establishing Session with Aruba Central API Gateway..."
@@ -68,7 +68,7 @@ def reboot(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -95,7 +95,7 @@ def blink(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -116,7 +116,7 @@ def nuke(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -126,11 +126,9 @@ def nuke(
     yes = yes_ if yes_ else yes
     dev = cli.cache.get_dev_identifier(device)
     nuke_msg = f"{typer.style('*Factory Default*', fg='red')} {typer.style(f'{dev.name}|{dev.serial}', fg='cyan')}"
-    if yes or typer.confirm(typer.style(f"Please Confirm: {nuke_msg}", fg="cyan")):
+    if yes or typer.confirm(typer.style(f"Please Confirm: {nuke_msg}", fg="cyan"), abort=True):
         resp = cli.central.request(cli.central.send_command_to_device, dev.serial, 'erase_configuration')
         typer.secho(str(resp), fg="green" if resp else "red")
-    else:
-        raise typer.Abort()
 
 
 @app.command(short_help="Save Device Running Config to Startup")
@@ -138,7 +136,7 @@ def save(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -155,7 +153,7 @@ def sync(
     device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -175,7 +173,7 @@ def move(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -201,7 +199,7 @@ def rename(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",
@@ -226,7 +224,7 @@ def kick(
     yes_: bool = typer.Option(False, "-y", hidden=True),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
                                  callback=cli.default_callback),
     account: str = typer.Option("central_info",
                                 envvar="ARUBACLI_ACCOUNT",

--- a/centralcli/cliupgrade.py
+++ b/centralcli/cliupgrade.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from pathlib import Path
+import sys
+import typer
+
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import cli
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import cli
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+from centralcli.constants import UpgradeArgs  # noqa
+
+app = typer.Typer()
+
+
+@app.command(short_help="Upgrade firmware on a specific device",)
+def device(
+    device: str = typer.Argument(..., metavar="Device: [serial #|name|ip address|mac address]",),
+    version: str = typer.Argument(None, help="Version to upgrade to [Default: recommended version]", show_default=False),
+    at: datetime = typer.Option(
+        None,
+        help="When to schedule upgrade. format: 'mm/dd/yyyy_hh:mm' or 'dd_hh:mm' (implies current month) [Default: Now]",
+        show_default=False,
+        formats=["%m/%d/%Y_%H:%M", "%d_%H:%M"],
+        ),
+    reboot: bool = typer.Option(False, "-R", help="Automatically reboot device after firmware download"),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
+                               callback=cli.debug_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                 callback=cli.default_callback),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                callback=cli.account_name_callback),
+) -> None:
+    yes = yes_ if yes_ else yes
+    dev = cli.cache.get_dev_identifier(device)
+    at = None if not at else int(round(at.timestamp()))
+
+    ver_msg = "Recommended version" if not version else version
+    if reboot:
+        ver_msg = f"{ver_msg} and reboot"
+
+    if yes or typer.confirm(
+        typer.style(
+            f"Upgrade {dev.name} to {ver_msg}?",
+            fg="bright_green",
+        ),
+        abort=True,
+    ):
+        resp = cli.central.request(cli.central.upgrade_firmware, scheduled_at=at, serial=dev.serial, reboot=reboot)
+        cli.display_results(resp)
+
+
+@app.command(short_help="Upgrade firmware by group",)
+def group(
+    group: str = typer.Argument(
+        None,
+        metavar="[GROUP NAME]",
+        help="Upgrade devices by group",
+        # autocompletion=cli.cache.get_group_names,  # TODO see if we can load cache earlier and autocomplete from cache
+    ),
+    version: str = typer.Argument(None, help="Version to upgrade to",),
+    at: datetime = typer.Option(
+        None,
+        help="When to schedule upgrade. format: 'mm/dd/yyyy hh:mm' or 'dd hh:mm' (implies current month) [Default: Now]",
+        show_default=False,
+        formats=["%m/%d/%Y %H:%M", "%d %H:%M"],
+        ),
+    dev_type: UpgradeArgs = typer.Option(None, help="Upgrade a specific device type",),
+    model: str = typer.Option(None, help="[applies to switches only] Upgrade a specific switch model"),
+    reboot: bool = typer.Option(False, "-R", help="Automatically reboot device after firmware download"),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
+                               callback=cli.debug_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                 callback=cli.default_callback),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                callback=cli.account_name_callback),
+) -> None:
+    yes = yes_ if yes_ else yes
+    group = cli.cache.get_group_identifier(group)
+    at = None if not at else int(round(at.timestamp()))
+
+    ver_msg = [typer.style("Upgrade", fg="cyan")]
+    if dev_type:
+        _dev_type = {
+            "switch": "HP",
+            "ap": "IAP",
+            "gateway": "CONTROLLER",
+        }
+        dev_type = _dev_type.get(dev_type, dev_type)
+        ver_msg += [f"{dev_type}s"] if dev_type != "switch" else ["switches"]
+    if model:
+        ver_msg += [f"model {typer.style(f'{model}', fg='bright_green')}"]
+
+    ver_msg += [f"in group {typer.style(f'{group.name}', fg='bright_green')}"]
+
+    if version:
+        _version = [f"to {typer.style('Recommended version', fg='bright_green')}"]
+    else:
+        _version = [f"to {typer.style(version, fg='bright_green')}"]
+    ver_msg += _version
+    ver_msg = " ".join(ver_msg)
+
+    if reboot:
+        ver_msg = f"{ver_msg} and reboot"
+
+    if yes or typer.confirm(
+        f"{ver_msg}?",
+        abort=True,
+    ):
+        resp = cli.central.request(
+            cli.central.upgrade_firmware,
+            scheduled_at=at,
+            group=group.name,
+            device_type=dev_type,
+            model=model,
+            reboot=reboot
+        )
+        cli.display_results(resp)
+        # typer.secho(str(resp), fg="green" if resp else "red")
+
+
+@app.command(short_help="Upgrade firmware for an IAP cluster",)
+def swarm(
+    swarm: str = typer.Argument(
+        None,
+        metavar="[IAP VC NAME|IAP SWARM ID|AP NAME|AP SERIAL|AP MAC]",
+        help="Upgrade firmware on an IAP cluster.  For AP name,serial,mac it will upgrade the cluster that AP belongs to.",
+    ),
+    version: str = typer.Argument(None, help="Version to upgrade to",),
+    at: datetime = typer.Option(
+        None,
+        help="When to schedule upgrade. format: 'mm/dd/yyyy hh:mm' or 'dd hh:mm' (implies current month) [Default: Now]",
+        show_default=False,
+        formats=["%m/%d/%Y %H:%M", "%d %H:%M"],
+        ),
+    reboot: bool = typer.Option(False, "-R", help="Automatically reboot device after firmware download"),
+    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
+    yes_: bool = typer.Option(False, "-y", hidden=True),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
+                               callback=cli.debug_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account",
+                                 callback=cli.default_callback),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                callback=cli.account_name_callback),
+) -> None:
+    yes = yes_ if yes_ else yes
+    at = None if not at else int(round(datetime.timestamp(at)))
+
+    # swarm = cli.cache.get_swarm_identifier(swarm)
+    class SwarmTemp:  # Temporary until swarm cache built
+        def __init__(self, swarm_id):
+            self.id = swarm_id
+    swarm = SwarmTemp(swarm)
+
+    ver_msg = [typer.style("Upgrade APs in swarm", fg="cyan")]
+    if version:
+        _version = [f"to {typer.style('Recommended version', fg='bright_green')}"]
+    else:
+        _version = [f"to {typer.style(version, fg='bright_green')}"]
+    ver_msg += _version
+
+    if reboot:
+        ver_msg += [typer.style("and reboot?", fg="cyan")]
+    ver_msg = " ".join(ver_msg)
+
+    if yes or typer.confirm(ver_msg, abort=True):
+        resp = cli.central.request(cli.central.upgrade_firmware, scheduled_at=at, swarm_id=swarm.id, reboot=reboot)
+        cli.display_results(resp)
+
+
+@app.callback()
+def callback():
+    """
+    Upgrade Firmware
+    """
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -244,6 +244,12 @@ class StatusOptions(str, Enum):
     DOWN = "DOWN"
 
 
+class UpgradeArgs(str, Enum):
+    ap = "ap"
+    switch = "switch"
+    gateway = "gateway"
+
+
 class LogAppArgs(str, Enum):
     account_setting = "account_setting"
     nms = "nms"

--- a/centralcli/vscodeargs.py
+++ b/centralcli/vscodeargs.py
@@ -30,6 +30,10 @@ def vscode_arg_handler():
             if " " in sys.argv[1] or not sys.argv[1]:
                 vsc_args = sys.argv.pop(1)
                 if vsc_args:
+                    # strip 'cli ' from 'cli command options' ocasionally paste in command from
+                    # external terminal where we use an alias cli to run cli.py with venv for dev.
+                    if vsc_args.startswith("cli "):
+                        vsc_args = vsc_args.lstrip("cli ")
                     if "\\'" in vsc_args:
                         _loc = vsc_args.find("\\'")
                         _before = vsc_args[:_loc - 1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.8a1"
+version = "0.8a2"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
`cencli add group test1 myP@ssw0rd`
```
cencli add group test1
Group Password: -masked-
Re-Enter to Confirm: -masked-
Add group test1? [y/N]: Y
  created
```
`--wired-tg`  and `--wlan-tg` options supported

This commits enhances cache to allow cache to be updated with a single group entry vs. a full cache update.  After add group, the group added is added to the cache.

Also cone group, and delete group.  Delete group allows multiple group entries
```
cencli delete group test1 test2 test3
```