### PR TITLE
fix: messaging when using default account, add account completion...

### DIFF
--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -56,9 +56,9 @@ log.debugv(f"config attributes: {json.dumps({k: str(v) for k, v in config.__dict
 from pycentral.base import ArubaCentralBase
 from .utils import Utils
 utils = Utils()
-from .cache import Cache
 from .response import Response
 from .central import CentralApi
+from .cache import Cache
 from .clicommon import CLICommon
 from . import constants
 

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -193,11 +193,11 @@ class Cache:
                 if m.name.startswith(incomplete):
                     out += [tuple([m.name, m.help_text])]
                 elif m.serial.startswith(incomplete):
-                    out += [tuple([f"{m.serial}({m.name})", m.help_text])]
+                    out += [tuple([m.serial, m.help_text])]
                 elif m.mac.strip(":.-").lower().startswith(incomplete.strip(":.-")):
-                    out += [tuple([f"{m.mac}({m.name})", m.help_text])]
+                    out += [tuple([m.mac, m.help_text])]
                 elif m.ip.address.startswith(incomplete):
-                    out += [tuple([f"{m.ip}({m.name})", m.help_text])]
+                    out += [tuple([m.ip, m.help_text])]
                 else:
                     # failsafe, shouldn't hit
                     out += [tuple([m.name, m.help_text])]

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -4,7 +4,7 @@
 from typing import Any, Literal, Dict, Union, List
 from aiohttp.client import ClientSession
 from tinydb import TinyDB, Query
-from centralcli import log, utils, config
+from centralcli import log, utils, config, CentralApi
 
 import asyncio
 import time
@@ -110,7 +110,7 @@ class CentralObject:
 class Cache:
     def __init__(
         self,
-        central=None,
+        central: CentralApi = None,
         data: Union[
             List[
                 dict,
@@ -171,6 +171,12 @@ class Cache:
     @property
     def all(self) -> dict:
         return {t.name: getattr(self, t.name) for t in self._tables}
+
+    @staticmethod
+    def account_completion(incomplete: str,):
+        for a in config.iter_accounts:
+            if a.lower().startwith(incomplete.lower()):
+                yield a
 
     def dev_completion(
         self,

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -168,8 +168,8 @@ class CLICommon:
             log.DEBUG = config.debug = debug
             return debug
 
-    @staticmethod
     # not used at the moment but could be used to allow unambiguous partial tokens
+    @staticmethod
     def normalize_tokens(token: str) -> str:
         return token.lower() if token not in CASE_SENSITIVE_TOKENS else token
 

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from aiohttp.client_exceptions import ContentTypeError
 from pycentral.base import ArubaCentralBase
 from . import cleaner

--- a/centralcli/vscodeargs.py
+++ b/centralcli/vscodeargs.py
@@ -1,4 +1,4 @@
-from centralcli import config, utils, log
+from centralcli import log
 from pathlib import Path
 import sys
 
@@ -6,24 +6,24 @@ import sys
 # -- break up arguments passed as single string from vscode promptString --
 def vscode_arg_handler():
 
-    def get_arguments_from_import(import_file: str, key: str = None) -> list:
-        """Get arguments from default import_file (stored_tasks.yaml)
+    # def get_arguments_from_import(import_file: str, key: str = None) -> list:
+    #     """Get arguments from default import_file (stored_tasks.yaml)
 
-        Args:
-            import_file (str): name of import file
-            key (str, optional): return single value for specific key if provided. Defaults to None.
+    #     Args:
+    #         import_file (str): name of import file
+    #         key (str, optional): return single value for specific key if provided. Defaults to None.
 
-        Returns:
-            list: updated sys.argv list.
-        """
-        # args = utils.read_yaml(import_file)
-        args = config.get_file_data(Path(import_file))
-        if key and key in args:
-            args = args[key]
+    #     Returns:
+    #         list: updated sys.argv list.
+    #     """
+    #     # args = utils.read_yaml(import_file)
+    #     args = config.get_file_data(Path(import_file))
+    #     if key and key in args:
+    #         args = args[key]
 
-        sys.argv += args
+    #     sys.argv += args
 
-        return sys.argv
+    #     return sys.argv
 
     try:
         if len(sys.argv) > 1:
@@ -46,18 +46,18 @@ def vscode_arg_handler():
                     else:
                         sys.argv += vsc_args.split()
 
-        if len(sys.argv) > 2:
-            _import_file, _import_key = None, None
-            if sys.argv[2].endswith((".yaml", ".yml", "json")):
-                _import_file = sys.argv.pop(2)
-                if not utils.valid_file(_import_file):
-                    if utils.valid_file(config.dir.joinpath(_import_file)):
-                        _import_file = config.dir.joinpath(_import_file)
+        # if len(sys.argv) > 2:
+        #     _import_file, _import_key = None, None
+        #     if sys.argv[2].endswith((".yaml", ".yml", "json")):
+        #         _import_file = sys.argv.pop(2)
+        #         if not utils.valid_file(_import_file):
+        #             if utils.valid_file(config.dir.joinpath(_import_file)):
+        #                 _import_file = config.dir.joinpath(_import_file)
 
-                if len(sys.argv) > 2:
-                    _import_key = sys.argv.pop(2)
+        #         if len(sys.argv) > 2:
+        #             _import_key = sys.argv.pop(2)
 
-                sys.argv = get_arguments_from_import(_import_file, key=_import_key)
+        #         sys.argv = get_arguments_from_import(_import_file, key=_import_key)
 
     except Exception as e:
         log.exception(f"Exception in vscode arg handler (arg split) {e.__class__.__name__}.{e}", show=True)
@@ -67,7 +67,8 @@ def vscode_arg_handler():
     try:
         # Update prev_args history file
         history_lines = None
-        history_file = config.base_dir / ".vscode" / "prev_args"
+        base_dir = Path(__file__).parent.parent
+        history_file = base_dir / ".vscode" / "prev_args"
         this_args = " ".join(sys.argv[1:])
         if not this_args:
             return
@@ -87,8 +88,8 @@ def vscode_arg_handler():
         # update launch.json default arg
         do_update = False
         launch_data = None
-        launch_file = config.base_dir / ".vscode" / "launch.json"
-        launch_file_bak = config.base_dir / ".vscode" / "launch.json.bak"
+        launch_file = base_dir / ".vscode" / "launch.json"
+        launch_file_bak = base_dir / ".vscode" / "launch.json.bak"
         if launch_file.is_file():
             launch_data = launch_file.read_text()
             launch_data = launch_data.splitlines()
@@ -99,8 +100,8 @@ def vscode_arg_handler():
                     if line != new_line:
                         do_update = True
                         log.debug(f"changing default arg for promptString:\n"
-                                  f"\t from: {line}\n"
-                                  f"\t to: {new_line}"
+                                  f"    from: {line}\n"
+                                  f"    to: {new_line}"
                                   )
                         launch_data[idx] = new_line
 
@@ -111,8 +112,8 @@ def vscode_arg_handler():
                     if line != new_line:
                         do_update = True
                         log.debug(f"changing options arg for pickString:\n"
-                                  f"\t from: {line}\n"
-                                  f"\t to: {new_line}"
+                                  f"    from: {line}\n"
+                                  f"    to: {new_line}"
                                   )
                         launch_data[idx] = new_line
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.10a11"
+version = "0.10a12"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
Was sending f"{mac}({name})" don't want it to complete with the
(name).  help_text is sent for shells that support it.