### PR TITLE
Add `show last`

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -192,6 +192,10 @@ class Cache:
         return self.EventDB.all()
 
     @property
+    def event_ids(self) -> list:
+        return [x["id"] for x in self.EventDB.all()]
+
+    @property
     def group_names(self) -> list:
         return [g["name"] for g in self.GroupDB.all()]
 
@@ -346,6 +350,15 @@ class Cache:
 
         for m in out:
             yield m[0], m[1]
+
+    def event_completion(
+        self,
+        incomplete: str,
+        args: List[str] = None,
+    ):
+        for event_id in self.event_ids:
+            if str(event_id).startswith(incomplete):
+                yield event_id, f"Details for Event with id {event_id}"
 
     # TODO add support for zip code city state etc.
     def site_completion(

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -30,7 +30,7 @@ tty = utils.tty
 CASE_SENSITIVE_TOKENS = ["R", "U"]
 TableFormat = Literal["json", "yaml", "csv", "rich", "simple", "tabulate", "raw", "action"]
 MsgType = Literal["initial", "previous", "forgot", "will_forget", "previous_will_forget"]
-console = Console()
+console = Console(emoji=False)
 
 
 class CLICommon:
@@ -262,6 +262,7 @@ class CLICommon:
         outfile: Path = None,
         sort_by: str = None,
         reverse: bool = False,
+        stash: bool = True,
         pad: int = None,
         set_width_cols: dict = None,
         full_cols: Union[List[str], str] = [],
@@ -284,8 +285,7 @@ class CLICommon:
                         data = sorted(data, key=lambda d: d[sort_by])
                     except TypeError as e:
                         print(
-                            f"[dark_orange3]Warning:[reset] Unable to sort by [cyan]{sort_by}. "
-                            f"[dark_orange3]TypeError:[reset] {e}"
+                            f"[dark_orange3]Warning:[reset] Unable to sort by [cyan]{sort_by}.\n{e} "
                         )
 
             if reverse:
@@ -305,7 +305,10 @@ class CLICommon:
                 "full_cols": full_cols
             }
             outdata = utils.output(**kwargs)
-            Path(config.cache_dir, "last_command").write_text(json.dumps({k: v for k, v in kwargs.items() if k != "config"}))
+            if stash:
+                Path(config.cache_dir, "last_command").write_text(
+                    json.dumps({k: v for k, v in kwargs.items() if k != "config"})
+                )
             typer.echo_via_pager(outdata) if pager and tty and len(outdata) > tty.rows else typer.echo(outdata)
 
             if outfile and outdata:
@@ -321,7 +324,8 @@ class CLICommon:
         pager: bool = True,
         outfile: Path = None,
         sort_by: str = None,
-        reverse: bool = None,
+        reverse: bool = False,
+        stash: bool = True,
         pad: int = None,
         exit_on_fail: bool = False,
         ok_status: Union[int, List[int], Dict[int, str]] = None,
@@ -349,6 +353,8 @@ class CLICommon:
             outfile (Path, optional): path/file of output file. Defaults to None.
             sort_by (Union[str, List[str], None] optional): column or columns to sort output on.
             reverse (bool, optional): reverse the output.
+            stash (bool, optional): stash (cache) the output of the command.  The CLI can re-display with
+                show last.  Default: True
             ok_status (Union[int, List[int], Tuple[int, str], List[Tuple[int, str]]], optional): By default
                 responses with status_code 2xx are considered OK and are rendered as green by
                 Output class.  provide int or list of int to override additional status_codes that

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -210,6 +210,10 @@ class Config:
     def cache_file(self):
         return self.default_cache_file if self.account in ["central_info", "default"] else self.cache_dir / f"{self.account}.json"
 
+    @property
+    def last_command_file(self):
+        return self.cache_dir / "last_command" if self.account in ["central_info", "default"] else self.cache_dir / f"{self.account}_last_command"
+
     def get(self, key: str, default: Any = None) -> Any:
         if key in self.data:
             return self.data.get(key, default)

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -650,6 +650,7 @@ state_pretty_to_abbrev = dict(map(reversed, state_abbrev_to_pretty.items()))
 
 NO_LOAD_COMMANDS = [
     "show config cencli",
+    "show last"
 ]
 NO_LOAD_FLAGS = [
     "--help",

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -477,7 +477,7 @@ class Utils:
             from rich.text import Text
             # from rich.progress import Progress
             from centralcli import constants
-            console = Console(record=True)
+            console = Console(record=True, emoji=False)
 
             customer_id, customer_name = "", ""
             # outdata = self.listify(outdata)


### PR DESCRIPTION
`show last` will re-display the result of the last command
(non action command).

Previous command can be repeated with `show last`.

Output format / sorting and output to file option can be chosen.
This allows re-display in alternate formats, or the same format
without actually performing the same API call again.