### PR TITLE
v0.21.2

### DIFF
--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1143,23 +1143,6 @@ class CentralApi(Session):
             'offset': offset,
             'limit': limit
         }
-        # params = {
-        #     "swarm_id": swarm_id,
-        #     "site": site,
-        #     "serial": serial,
-        #     "macaddr": macaddr,
-        #     "model": model,
-        #     "cluster_id": cluster_id,
-        #     "stack_id": stack_id,
-        #     "status": None if not status else status.title(),
-        #     "fields": fields,
-        #     "show_resource_details": str(show_resource_details).lower(),
-        #     "calculate_client_count": str(calculate_client_count).lower(),
-        #     "calculate_ssid_count": str(calculate_ssid_count).lower(),
-        #     "public_ip_address": public_ip_address,
-        #     "limit": limit,
-        #     "offset": offset,
-        # }
 
         url = f"/monitoring/v1/{dev_type}"
         if dev_type == "aps":
@@ -2050,7 +2033,6 @@ class CentralApi(Session):
             if not resp:
                 return resp
             if len(site_list) > 1:
-                # TODO _batch_requests
                 ret = await self._batch_request(
                     [
                         self.BatchRequest(self.post, (url,), json_data=_json, callback=cleaner._unlist)
@@ -3137,6 +3119,8 @@ class CentralApi(Session):
 
         return await self.put(url, json_data=json_data)
 
+    # TODO changte to use consistent dev tpe ap gw cx sw
+    # convert to the stuff apigw wants inside method
     async def upgrade_firmware(
         self,
         scheduled_at: int = None,
@@ -3183,6 +3167,7 @@ class CentralApi(Session):
 
         return await self.post(url, json_data=json_data)
 
+    # API-FLAW only accepts swarm id for IAP, AOS10 show as IAP but no swarm id.  serial is rejected.
     async def get_upgrade_status(self, swarm_id: str = None, serial: str = None) -> Response:
         """Get firmware upgrade status.
 

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -31,7 +31,9 @@ except (ImportError, ModuleNotFoundError) as e:
 def epoch_convert(func):
     @functools.wraps(func)
     def wrapper(epoch):
-        if len(str(int(epoch))) > 10:
+        # FIXME don't know why started getting ValueError: invalid literal for int() with base 10: '24 minutes 20 seconds'
+        # appears show all was hitting the cleaner 2x
+        if str(epoch).isdigit() and len(str(int(epoch))) > 10:
             epoch = epoch / 1000
         return func(epoch)
 
@@ -515,7 +517,7 @@ def get_audit_logs(data: List[dict], cache_update_func: callable = None) -> List
     data = [dict(short_value(k, d.get(k)) for k in field_order) for d in data]
     data = strip_no_value(data)
 
-    if len(data) > 1 and cache_update_func:
+    if len(data) > 0 and cache_update_func:
         idx, cache_list = 1, []
         for d in data:
             if d.get("has details") is True:

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -702,7 +702,6 @@ def profile(
     # https://stackoverflow.com/questions/55880601/how-to-use-profiler-with-click-cli-in-python
 
 
-
 def all_commands_callback(ctx: typer.Context, update_cache: bool):
     if not ctx.resilient_parsing:
         account, debug, debugv, default, update_cache = None, None, None, None, None
@@ -723,13 +722,15 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
                 if "U" in arg:
                     update_cache = True
 
-        account = account or os.environ.get("ARUBACLI_ACCOUNT", False)
+        account = account or os.environ.get("ARUBACLI_ACCOUNT")
         debug = debug or os.environ.get("ARUBACLI_DEBUG", False)
 
         if default:
             default = cli.default_callback(ctx, True)
-        elif account:
+        # elif account:
+        else:
             cli.account_name_callback(ctx, account=account)
+
         if debug:
             cli.debug_callback(ctx, debug=debug)
         if debugv:
@@ -744,7 +745,7 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
 
 @app.callback()
 def callback(
-    ctx: typer.Context,
+    # ctx: typer.Context,``
     debug: bool = typer.Option(False, "--debug", is_flag=True, envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
                             #    callback=all_commands_callback),
     debugv: bool = typer.Option(False, "--debugv", is_flag=True, help="Enable Verbose Debug Logging",),

--- a/centralcli/cliadd.py
+++ b/centralcli/cliadd.py
@@ -195,17 +195,17 @@ def group(
     # -- // Error on combinations that are not allowed by API \\ --
     if not aos10 and microbranch:
         print(
-            f"[bright_red]Microbranch is only valid if group is configured as AOS10 group ({color('--aos10')})."
+            f":x: [bright_red]Microbranch is only valid if group is configured as AOS10 group ({color('--aos10')})."
         )
         raise typer.Exit(1)
     if (mon_only_sw or mon_only_cx) and wired_tg:
-        print("[bright_red]Error: Monitor only is not valid for template group.")
+        print(":x: [bright_red]Error: Monitor only is not valid for template group.")
         raise typer.Exit(1)
     if not [t for t in allowed_types if allowed_types in ["cx", "sw"]] and (mon_only_sw or mon_only_cx):
-        print("[bright_red]Error: Monitor only is not valid without '--sw' or '--cx' (Allowed Device Types)")
+        print(":x: [bright_red]Error: Monitor only is not valid without '--sw' or '--cx' (Allowed Device Types)")
         raise typer.Exit(1)
     if gw_role and gw_role == "wlan" and not aos10:
-        print("[bright_red]WLAN role for Gateways requires the group be configured as AOS10 via --aos10 option.")
+        print(":x: [bright_red]WLAN role for Gateways requires the group be configured as AOS10 via --aos10 option.")
         raise typer.Exit(1)
     if all([x is None for x in [ap, sw, cx, gw]]):
         print("[green]No Allowed devices provided. Allowing all device types.")

--- a/centralcli/clidel.py
+++ b/centralcli/clidel.py
@@ -190,7 +190,7 @@ def firmware(
         group = cli.cache.get_group_identifier(group).name
 
     kwargs = {
-        'device_type': _type_to_name.get(device_type.upper(), device_type),
+        'device_type': _type_to_name.get(device_type.lower(), device_type),
         'group': group
     }
 

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -291,11 +291,8 @@ def group(
             **kwargs
         )
         cli.display_results(resp, tablefmt="action")
-        # if resp:  # resp:
-        #     asyncio.run(
-        #         cli.cache.update_group_db({'name': group.name, 'template group': {'Wired': wired_tg, 'Wireless': wlan_tg}})
-        #     )
 
+# TODO command for update site
 
 @app.command(
     short_help="Update group properties",

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -93,8 +93,6 @@ def ask(
     return choice
 
 
-
-
 def _get_config_file(dirs: List[Path]) -> Path:
     dirs = [dirs] if not isinstance(dirs, list) else dirs
     for _dir in dirs:
@@ -296,13 +294,21 @@ class Config:
                 last_cmd_ts = float(last_cmd_ts)
 
                 # last account sticky file handling -- messaging is in cli callback --
+                console = Console()
                 if self.forget:
                     if time.time() > last_cmd_ts + (self.forget * 60):
                         self.sticky_account_file.unlink(missing_ok=True)
+                        _m = f":warning: Forget option set for [cyan]{last_account}[/], and expiration has passed.  [bright_green]reverting to default account[/]"
+                        _m = f"{_m}\nUse [cyan]--account[/] option or set environment variable ARUBACLI_ACCOUNT to use alternate account"
+                        console.print(_m)
+                        if not Confirm(f"Proceed using default account", console=console):
+                            abort()
                     else:
                         account = last_account
+                        console.print(f":warning: [magenta]Using Account[/] [cyan]{account}[/]\n")
                 else:
                     account = last_account
+                    console.print(f":warning: [magenta]Using Account[/] [cyan]{account}[/]\n")
         else:
             if account in self.data:
                 self.sticky_account_file.parent.mkdir(exist_ok=True)

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -334,12 +334,12 @@ class LibToAPI:
 
         # from CentralApi consistent value to Random API value
         self.monitoring_to_api = {
-             "gw": "gateways",
-             "ap": "aps",
-             "switch": "switches",
-             "cx": "switches",
-             "sw": "switches"
-         }
+            "gw": "gateways",
+            "ap": "aps",
+            "switch": "switches",
+            "cx": "switches",
+            "sw": "switches"
+        }
         self.site_to_api = {
             "gw": "CONTROLLER",
             "ap": "IAP",

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -611,7 +611,6 @@ class LogSortBy(str, Enum):
     ip = "ip"
     user = "user"
     id = "id"
-    has_details = "has_details"
 
 
 LIB_DEV_TYPE = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.21.1"
+version = "0.21.2"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -46,3 +46,6 @@ def test_rate_limit():
     print(b_resp[-1].rl.text)
     assert all([r.reason == "OK" for r in central.requests])
     assert len(b_reqs) == len(central.requests)
+
+if __name__ == '__main__':
+    test_rate_limit()


### PR DESCRIPTION
[fix] on first run would not display results show all | groups | templates | sites
[fix] delete firmware compliance dev-type translation
[fix] restore alternate account messaging
[fix] `cencli show logs` allowed an invalid field for `--sort` option
[refactor] per second rate-limit logic.  Prior logic ran into issues with longer running API calls
[enhance] batch rename aps, add support for site name in substr format, warning msgs on # of API calls required.