### PR TITLE
v0.24.8

### DIFF
--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -611,7 +611,7 @@ class CentralApi(Session):
         Returns:
             Response: CentralAPI Response object
         """
-        # This logic is here because Central has both methods, but given a wlan client mac
+        # API-FLAW This logic is here because Central has both methods, but given a wlan client mac
         # central will return the client details even when using the wired url
 
         # Mac match logic is jacked in central

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -198,8 +198,17 @@ _short_key = {
 }
 
 
-def strip_outer_keys(data: dict) -> dict:
-    if not isinstance(data, dict):
+def strip_outer_keys(data: dict) -> Union[list, dict]:
+    """strip unnecessary wrapping key from API response payload
+
+    Args:
+        data (dict): The response payload (aiohttp.Response.json())
+
+    Returns:
+        Union[list, dict]: typically list of dicts
+    """
+    # return unaltered payload if payload is not a dict, or if it has > 5 keys (wrapping typically has 2 sometimes 3)
+    if not isinstance(data, dict) or len(data.keys()) > 5:
         return data
 
     data = data if "result" not in data else data["result"]

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -32,8 +32,6 @@ from centralcli.constants import DevTypes
 def epoch_convert(func):
     @functools.wraps(func)
     def wrapper(epoch):
-        # FIXME don't know why started getting ValueError: invalid literal for int() with base 10: '24 minutes 20 seconds'
-        # appears show all was hitting the cleaner 2x
         if str(epoch).isdigit() and len(str(int(epoch))) > 10:
             epoch = epoch / 1000
         return func(epoch)
@@ -343,12 +341,17 @@ def _client_concat_associated_dev(
         "interface mac",
         "gateway serial",
     ]
+
+    # FIXME get_dev_identifier can fail if client is connected to device that is not in the cache.
+    # even with a cache update.  doing show all is fine, but update cache for whatever reason with this method
+    # is causing some kind of SSL error, which results in cache lookup failure.
+    # silent=True, retry=False, resolves.  Would need no_match OK as get_dev_identifier fails if no match.
     dev, _gw, data["gateway"] = "", "", {}
     if data.get("associated_device"):
-        dev = cache.get_dev_identifier(data["associated_device"],)
+        dev = cache.get_dev_identifier(data["associated_device"])
 
     if data.get("gateway_serial"):
-        _gw = cache.get_dev_identifier(data["gateway_serial"],)
+        _gw = cache.get_dev_identifier(data["gateway_serial"])
         _gateway = {
             "name": _gw.name,
             "serial": data.get("gateway_serial", ""),
@@ -358,7 +361,7 @@ def _client_concat_associated_dev(
         else:
             data["gateway"] = _gw.name or data["gateway_serial"]
     _connected = {
-        "name": None if not hasattr(dev, "name") else dev.name,
+        "name": data.get("associated_device") if not hasattr(dev, "name") else dev.name,
         "type": data.get("connected_device_type"),
         "serial": data.get("associated_device"),
         "mac": data.get("associated_device_mac"),

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -689,7 +689,7 @@ def stop(
         raise typer.Exit(0)
 
 # TODO Unhide once impact of archive is known post GreenLake... still licensed and shows in device list.
-@app.command(help="Archive devices", hidden=False)
+@app.command(short_help="Archive devices", hidden=False)
 def archive(
     devices: List[str] = typer.Argument(..., metavar=iden.dev_many, autocompletion=cli.cache.dev_completion),
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
@@ -701,6 +701,16 @@ def archive(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ) -> None:
+    """Archive devices.  This has less meaning/usefulness with the transition to GreenLake.
+
+    cencli archive <devices>, followed by cencli unarchive <devices> removes any subscriptions
+    and the devices assignment to the Aruba Central App in GreenLake.
+
+    Archive removes the GreenLake assignment, but the device can't be added to a different account
+    until it's unarchived.
+
+    Just use cencli deleve device ... or cencli batch delete devices
+    """
     yes = yes_ if yes_ else yes
     devices = [cli.cache.get_dev_identifier(dev, silent=True, include_inventory=True) for dev in devices]
 
@@ -712,7 +722,7 @@ def archive(
         _msg = f"{_msg}\n    {_dev_msg}\n"
     else:
         dev = devices[0]
-        _msg = f"{_msg} [cyan]{dev.name}[/]|[cyan]{dev.serial}[/]|[cyan]{dev.mac}[/]\n"
+        _msg = f"{_msg} [cyan]{dev.name}[/]|[cyan]{dev.serial}[/]|[cyan]{dev.mac}[/]"
     print(_msg)
     if yes or typer.confirm("\nProceed?"):
         resp = cli.central.request(cli.central.archive_devices, [d.serial for d in devices])
@@ -746,7 +756,7 @@ def unarchive(
         _msg = f"{_msg}\n    {_dev_msg}\n"
     else:
         dev = devices[0]
-        _msg = f"{_msg} [cyan]{dev.name}[/]|[cyan]{dev.serial}[/]|[cyan]{dev.mac}[/]\n"
+        _msg = f"{_msg} [cyan]{dev.name}[/]|[cyan]{dev.serial}[/]|[cyan]{dev.mac}[/]"
     print(_msg)
 
     resp = cli.central.request(cli.central.unarchive_devices, [d.serial for d in devices])

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -378,7 +378,6 @@ class CLICommon:
         stash: bool = True,
         pad: int = None,
         exit_on_fail: bool = False,
-        # ok_status: Union[int, List[int], Dict[int, str]] = None,
         set_width_cols: dict = None,
         full_cols: Union[List[str], str] = [],
         fold_cols: Union[List[str], str] = [],
@@ -417,7 +416,6 @@ class CLICommon:
             full_cols (list): columns to ensure are displayed at full length (no wrap no truncate)
             cleaner (callable, optional): The Cleaner function to use.
         """
-        # TODO remove ok_status, and handle in CentralAPI method (set resp.ok = True)
         if pad:
             log.error("Deprecated pad parameter referenced in display_results", show=True)
 

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -1394,7 +1394,7 @@ def wlans(
 # FIXME show clients wireless <tab completion> does not filter based on type of device
 # FIXME show clients wireless AP-NAME does not filter only devices on that AP
 # Same applies for wired
-@app.command(short_help="Show clients/details")
+@app.command(help="Show clients/details")
 def clients(
     filter: ClientArgs = typer.Argument('all', case_sensitive=False, ),
     device: List[str] = typer.Argument(
@@ -1403,9 +1403,6 @@ def clients(
         help="Show clients for a specific device or multiple devices.",
         autocompletion=cli.cache.dev_client_completion,
     ),
-    # os_type:
-    # band:
-    # _: str = typer.Argument(None, hidden=True, autocompletion=cli.cache.null_completion),
     group: str = typer.Option(None, metavar="<Group>", help="Filter by Group", autocompletion=cli.cache.group_completion),
     site: str = typer.Option(None, metavar="<Site>", help="Filter by Site", autocompletion=cli.cache.site_completion),
     label: str = typer.Option(None, metavar="<Label>", help="Filter by Label", ),

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -108,6 +108,7 @@ def template(
         typer.secho("template file not provided.", fg="cyan")
         do_prompt = True
 
+    # TODO specify CTRL-Z / CTRL-D based on os
     payload = None
     if do_prompt:
         payload = utils.get_multiline_input(

--- a/centralcli/strings.py
+++ b/centralcli/strings.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from rich.console import Console
 from centralcli import log
 
 # [italic]Also supports a simple list of serial numbers with no header 1 per line.[reset]  # TODO implement this device del
@@ -135,6 +136,31 @@ name\nphl-access\nsan-dc-tor\ncom-branches
 {common_add_delete_end}
 """
 
+clibatch_delete_devices_help = f"""
+[bright_green]Perform batch Delete operations using import data from file.[/]
+
+[cyan]cencli batch delete devices <IMPORT_FILE>[/]
+
+    will remove any subscriptions/licenses from the device and disassociate the device with the Aruba Central app in GreenLake.  It will then remove the device from the monitoring views, along with the historical data for the device.
+
+    Note: devices can only be removed from monitoring views if they are in a down state.  This command will delay/wait for any Up devices to go Down after the subscriptions/assignment to Central is removed, but it can also be ran again.  It will pick up where it left off, skipping any steps that have already been performed.
+
+cencli delete sites <IMPORT_FILE> and cencli delte groups <IMPORT_FILE>
+    Do what you'd expect.
+
+NOTE: The Aruba Central API gateway currently does not have an API endpoint to remove
+device assignments in GreenLake.
+"""
+
+
+def do_capture(text: str) -> str:
+    con = Console()
+    con.begin_capture()
+    con.print(text)
+    ret = con.end_capture()
+    return ret
+
+
 class ImportExamples:
     def __init__(self):
         self.add_devices = clibatch_add_devices
@@ -148,3 +174,19 @@ class ImportExamples:
         if not hasattr(self, key):
             log.error(f"An attempt was made to get {key} attr from ImportExamples which is not defined.")
             return f":warning: Error no str defined  ImportExamples.{key}"
+
+class LongHelp:
+    def __init__(self):
+        self.batch_delete_devices = do_capture(clibatch_delete_devices_help)
+
+    def __getattr__(self, key: str):
+        if not hasattr(self, key):
+            log.error(f"An attempt was made to get {key} attr from ImportExamples which is not defined.")
+            return f":warning: Error no str defined  ImportExamples.{key}"
+        else:  # FIXME This doesn't seem to hit changed to using do_capture at init
+            con = Console()
+            attr = getattr(self, key)
+            con.begin_capture()
+            con.print(attr)
+            ret = con.end_capture()
+            return ret

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -267,7 +267,7 @@ class Utils:
     # TODO deprecated validate not used, moved to Response
     @staticmethod
     def get_multiline_input(prompt: str = None, print_func: callable = print,
-                            return_type: str = None, abort_str: str = "exit", **kwargs) -> Union[List[str], dict, str]:
+                            return_type: str = "str", abort_str: str = "exit", **kwargs) -> Union[List[str], dict, str]:
         def _get_multiline_sub(prompt: str = prompt, print_func: callable = print_func, **kwargs):
             prompt = prompt or \
                 "Enter/Paste your content. Then Ctrl-D or Ctrl-Z -> Enter ( windows ) to submit.\n Enter 'exit' to abort"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "0.24.7"
+version = "0.24.8"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
fix `show events <id>`
colorize help text for `batch delete device` (more to come)
change default return type of `get_multiline_input`
fix `cencli show clients mac <mac>`  (prevent `strip_outer_keys` from altering a non wrapped payload when the payload happens to have one of the outer keys we look for)