### PR TITLE
v1.10

### DIFF
--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -1556,7 +1556,8 @@ TZDB = Literal[
 
 NO_LOAD_COMMANDS = [
     "show config cencli",
-    "show last"
+    "show last",
+    "convert"
 ]
 
 

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -433,6 +433,7 @@ class Session():
 
                 # TODO spinner steps on each other during long running requests
                 # need to check store prev msg when updating then restore it if that thread is still running
+                self.spinner.stop() # Fix spinner was not starting with below call to start until first stopping it.
                 self.spinner.start(spin_txt_run)
                 self.running_spinners += [spin_txt_run]
                 self.req_cnt += 1  # TODO may have deprecated now that logging requests
@@ -743,7 +744,7 @@ class Session():
     async def pause(start: float) -> None:
         _elapsed = time.perf_counter() - start
         _pause = (int(_elapsed) + 1) - _elapsed
-        log.debug("PAUSE {_pause:.2f}s...")
+        log.debug(f"PAUSE {_pause:.2f}s...")
         time.sleep(_pause)
 
     async def _batch_request(self, api_calls: List[BatchRequest], continue_on_fail: bool = False,) -> List[Response]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "1.9"
+version = "1.10"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
- fix spinner not starting on first request
- improve `cencli upgrade device` now automatically accommodates API oddness as it relates to AP upgrade (need to send serial as swarm_id when upgrading individual AP)