### PR TITLE
:bookmark: v2.3.3

### DIFF
--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -295,6 +295,11 @@ class BatchRenameArgs(str, Enum):
     groups = "groups"
 
 
+class EnableDisableArgs(str, Enum):
+    auto_sub = "auto-sub"
+
+
+
 class DhcpArgs(str, Enum):
     clients = "clients"
     server = "server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "2.3.2"
+version = "2.3.3"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
:sparkles: Add commands to show/disable/enable auto-subscription

:bug: The enable/disable commands are currently hidden. As GreenLake and the API have some inconsistencies.

auto-sub advanced-switch-6300 will result in the API showing it is
enabled for all switches (this is OK).   However GreenLake doesn't reflect
the change.  The API to disable unsubscribe will return OK, but doesn't appear
to change anything.  The only way to get the API (that shows what is enabled)
to clear auto-sub is to create then delete auto-sub from GreenLake UI.