### PR TITLE
🔖 v4.0.0

### DIFF
--- a/centralcli/boilerplate/allcalls.py
+++ b/centralcli/boilerplate/allcalls.py
@@ -602,8 +602,8 @@ class AllCalls(CentralApi):
 
     async def airgroup_views_get_traffic_summary_v1(
         self,
-        start_time: int,
-        end_time: int,
+        start_time: int = None,
+        end_time: int = None,
         label: str = None,
     ) -> Response:
         """Get AirGroup Traffic Summary in terms of Packets.
@@ -681,8 +681,8 @@ class AllCalls(CentralApi):
 
     async def airgroup_views_get_service_query_summary_v1(
         self,
-        start_time: int,
-        end_time: int,
+        start_time: int = None,
+        end_time: int = None,
         label: str = None,
     ) -> Response:
         """Retrieves a summary of all the services queried for.
@@ -707,8 +707,8 @@ class AllCalls(CentralApi):
 
     async def airgroup_views_get_server_distribution_v1(
         self,
-        start_time: int,
-        end_time: int,
+        start_time: int = None,
+        end_time: int = None,
         label: str = None,
     ) -> Response:
         """Retrieves a summary of the servers connected to AirGroup.

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -741,6 +741,7 @@ class Cache:
     # TODO put client names with spaces in quotes
     def dev_client_completion(
         self,
+        ctx: typer.Context,
         incomplete: str,
         args: List[str] = [],
     ) -> Generator[Tuple[str, str], None, None] | None:
@@ -763,15 +764,14 @@ class Cache:
             err_console.print(":warning:  Invalid config")
             return
 
-        gen = self.dev_switch_ap_completion
 
-        if args:
-            if args[-1].lower() == "wireless":
-                gen = self.dev_ap_completion
-            elif args[-1].lower() == "wired":
-                gen = self.dev_switch_completion
-            elif args[-1].lower() == "all":
-                return
+        if ctx.params.get("wireless"):
+            gen = self.dev_ap_completion
+        elif ctx.params.get("wired"):
+            gen = self.dev_switch_completion
+        else:
+            gen = self.dev_switch_ap_completion
+            # return
 
         for m in [dev for dev in gen(incomplete, args)]:
             yield m
@@ -2129,7 +2129,7 @@ class Cache:
         retry: bool = True,
         completion: bool = False,
         silent: bool = False,
-    ) -> CentralObject:
+    ) -> CentralObject | List[CentralObject]:
         retry = False if completion else retry
         if isinstance(query_str, (list, tuple)):
             query_str = " ".join(query_str)
@@ -2225,7 +2225,7 @@ class Cache:
         multi_ok: bool = False,
         completion: bool = False,
         silent: bool = False,
-    ) -> List[CentralObject]:
+    ) -> CentralObject | List[CentralObject]:
         """Allows Case insensitive group match"""
         retry = False if completion else retry
         for _ in range(0, 2):
@@ -2309,7 +2309,7 @@ class Cache:
         retry: bool = True,
         completion: bool = False,
         silent: bool = False,
-    ) -> CentralObject:
+    ) -> CentralObject | List[CentralObject]:
         """Allows Case insensitive label match"""
         retry = False if completion else retry
         for _ in range(0, 2):

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -7,12 +7,13 @@ import asyncio
 import time
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Sequence, Set, Union
+from typing import Any, Dict, Iterable, List, Literal, Sequence, Set, Union, Generator, Tuple
 
 import typer
 from rich import print
 from rich.console import Console
 from tinydb import Query, TinyDB
+from tinydb.table import Table
 
 from centralcli import CentralApi, Response, cleaner, config, constants, log, models, render, utils
 
@@ -289,21 +290,21 @@ class Cache:
         self.responses = CacheResponses()
         # self.LicenseDB = LicenseDB()  # for the benefit of sphinx
         if config.valid and config.cache_dir.exists():
-            self.DevDB = TinyDB(config.cache_file)
-            self.InvDB = self.DevDB.table("inventory")
-            self.SiteDB = self.DevDB.table("sites")
-            self.GroupDB = self.DevDB.table("groups")
-            self.TemplateDB = self.DevDB.table("templates")
-            self.LabelDB = self.DevDB.table("labels")
-            self.LicenseDB = self.DevDB.table("licenses")
-            self.ClientDB = self.DevDB.table("clients")  # Updated only when show clients is ran
+            self.DevDB: TinyDB = TinyDB(config.cache_file)
+            self.InvDB: Table = self.DevDB.table("inventory")
+            self.SiteDB: Table = self.DevDB.table("sites")
+            self.GroupDB: Table = self.DevDB.table("groups")
+            self.TemplateDB: Table = self.DevDB.table("templates")
+            self.LabelDB: Table = self.DevDB.table("labels")
+            self.LicenseDB: Table = self.DevDB.table("licenses")
+            self.ClientDB: Table = self.DevDB.table("clients")  # Updated only when show clients is ran
             # log db is used to provide simple index to get details for logs
             # vs the actual log id in form 'audit_trail_2021_2,...'
             # it is updated anytime show logs is ran.
-            self.LogDB = self.DevDB.table("logs")
-            self.EventDB = self.DevDB.table("events")
-            self.HookConfigDB = self.DevDB.table("wh_config")
-            self.HookDataDB = self.DevDB.table("wh_data")
+            self.LogDB: Table = self.DevDB.table("logs")
+            self.EventDB: Table = self.DevDB.table("events")
+            self.HookConfigDB: Table = self.DevDB.table("wh_config")
+            self.HookDataDB: Table = self.DevDB.table("wh_data")
             self._tables = [self.DevDB, self.InvDB, self.SiteDB, self.GroupDB, self.TemplateDB, self.LabelDB, self.LicenseDB, self.ClientDB]
             self.Q = Query()
             if data:
@@ -315,7 +316,7 @@ class Cache:
         if refresh:
             self.check_fresh(refresh)
 
-    def __iter__(self) -> list:
+    def __iter__(self) -> Generator[Tuple[str, TinyDB | Table], None, None]:
         for db in self._tables:
             yield db.name(), db.all()
 
@@ -464,6 +465,11 @@ class Cache:
 
     # TODO maybe build script to gather completion and help text and place in flat file
     def method_test_completion(self, incomplete: str, args: List[str] = []):
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         if self.central is not None:
             methods = [
                 d for d in self.central.__dir__()
@@ -487,6 +493,11 @@ class Cache:
                 yield m
 
     def smg_kw_completion(self, ctx: typer.Context, incomplete: str, args: List[str] = []):
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         kwds = ["group", "mac", "serial"]
         out = []
 
@@ -525,6 +536,10 @@ class Cache:
         incomplete: str,
         args: List[str] = None,
     ):
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
 
         # HACK click 8.x broke args being passed to completion functions.
         # if args is not None:
@@ -572,13 +587,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = [],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Device completion for returning matches that are either switch or AP
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
-            args (List[str], optional): The previous arguments/commands on CLI.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_dev_identifier(incomplete, dev_type=["switch"], completion=True)
 
         out = []
@@ -596,7 +620,7 @@ class Cache:
         ctx: typer.Context,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for commands that allow a list of devices followed by group/site.
 
         i.e. cencli move dev1 dev2 dev3 site site_name group group_name
@@ -607,8 +631,14 @@ class Cache:
             args (List[str], optional): The prev args passed into the command.
 
         Yields:
-            tuple: matching completion string, help text
+            Generator[Tuple[str, str], None, None]: Matching completion string, help text, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         if not args:  # HACK resolves click 8.x issue now pinned to 7.2 until fixed upstream
             args = [k for k, v in ctx.params.items() if v and k[:2] not in ["kw", "va"]]
             args += [v for k, v in ctx.params.items() if v and k[:2] in ["kw", "va"]]
@@ -660,12 +690,16 @@ class Cache:
         # ctx: typer.Context,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for argument where only APs are valid.
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
         # if not args:
         #     _last = ctx.command_path.split()[-1]
@@ -673,6 +707,11 @@ class Cache:
         #         args = ctx.params[_last]
         #     else:
         #         args = [k for k, v in ctx.params.items() if v and k not in ["account", "debug"]]
+
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
 
         dev_types = ["ap"]
         match = self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True)
@@ -702,7 +741,7 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = [],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for client output.
 
         Returns only devices that apply based on filter provided in command, defaults to clients
@@ -711,8 +750,17 @@ class Cache:
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
-            args (List[str], optional): The previous arguments/commands on CLI.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Tuple with completion and help text, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         gen = self.dev_switch_ap_completion
 
         if args:
@@ -730,13 +778,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = [],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Device completion for returning matches that are either switch or AP
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Yields Tuple with completion and help text, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_dev_identifier(incomplete, dev_type=["switch", "ap"], completion=True)
 
         # TODO fancy map to ensure dev.name, dev.mac, dev.serial, dev.ip are all not in args
@@ -753,13 +810,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Device completion that returns only ap and gw.
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Yields Tuple with completion and help text, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         dev_types = ["ap", "gw"]
         _match = self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True)
 
@@ -782,13 +848,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Device completion that returns only switches and gateways.
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         dev_types = ["switch", "gw"]
         match = [m for m in self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True) if m.generic_type in dev_types]
 
@@ -805,7 +880,7 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for device idens where only gateways are valid.
 
         Args:
@@ -813,10 +888,15 @@ class Cache:
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
 
         Yields:
-            tuple: name and help_text for the device
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
-        # match = [m for m in self.dev_completion(incomplete) if m.generic_type == "gw"]
-        match = self.get_identifier(incomplete, ["dev"], device_type="gw", completion=True)
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
+        match = self.get_dev_identifier(incomplete, device_type="gw", completion=True)
 
         out = []
         if match:
@@ -832,19 +912,29 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ) -> List[tuple[str, str]]:
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for argument that can be either group or device.
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
-        group_match = self.get_group_identifier(incomplete, completion=True)
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
+        # group_match = self.get_group_identifier(incomplete, completion=True)
 
         dev_types = ["ap", "gw"]
-        match = self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True)
+        # match = self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True)
+        match = self.get_identifier(incomplete, ["group", "dev"], device_type=dev_types, completion=True)
 
-        match = group_match + match
+        # match = group_match + match
 
 
         out = []
@@ -863,23 +953,29 @@ class Cache:
         # not appear in zsh
 
         for m in out:
-            log.debug(f"yielding to completion {m}")  # DEBUG remove me serial completion yielding expected tuple but does not appear in zsh
+            log.debug(f"yielding to completion {m}")  # FIXME DEBUG remove me serial completion yielding expected tuple but does not appear in zsh
             yield m
 
     def group_dev_gw_completion(
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for argument that can be either group or a gateway.
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
             args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
-        # dev_types = ["gw"]
-        # dev_match = self.get_dev_identifier(incomplete, dev_type=dev_types, completion=True)
-        # match = [*self.get_group_identifier(incomplete, completion=True), *dev_match]
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_identifier(incomplete, ["group", "dev"], device_type="gw", completion=True)
 
         out = []
@@ -894,14 +990,23 @@ class Cache:
     def send_cmds_completion(
         self,
         incomplete: str,
-        args: List[str] = None,
-    ):
+        args: List[str] = [],
+    ) -> Generator[Tuple[str, str], None, None] | None:
         """Completion for argument that can be either group, site, or a gateway or keyword "commands".
 
         Args:
             incomplete (str): The last partial or full command before completion invoked.
-            args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the device, or
+                Returns None if config is invalid
         """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         if args[-1] == "all":
             yield "commands"
         elif args[-1] in ["commands", "file"]:
@@ -930,7 +1035,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = [],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        """Completion for groups (by name).
+
+        Args:
+            incomplete (str): The last partial or full command before completion invoked.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the group, or
+                Returns None if config is invalid
+        """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_group_identifier(
             incomplete,
             completion=True,
@@ -947,8 +1067,23 @@ class Cache:
     def label_completion(
         self,
         incomplete: str,
-        args: List[str] = None,
-    ):
+        args: List[str] = [],
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        """Completion for labels.
+
+        Args:
+            incomplete (str): The last partial or full command before completion invoked.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]:  Name and help_text for the label, or
+                Returns None if config is invalid
+        """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_label_identifier(
             incomplete,
             completion=True,
@@ -966,7 +1101,22 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        """Completion for clients.
+
+        Args:
+            incomplete (str): The last partial or full command before completion invoked.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the client, or
+                Returns None if config is invalid
+        """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_client_identifier(
             incomplete,
             completion=True,
@@ -995,23 +1145,47 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        """Completion for events.
+
+        Args:
+            incomplete (str): The last partial or full command before completion invoked.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to [].
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Value and help_text for the event, or
+                Returns None if config is invalid
+        """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         for event in self.events:
             if event["id"].startswith(incomplete):
                 yield event["id"], f"{event['id']}|{event['device'].split('Group:')[0].rstrip()}"
-
-        # for match, help_txt in sorted(matches, key=lambda i: int(i[0])):
-        #     yield match, help_txt
-        # for event_id in self.event_ids:
-        #     if event_id.startswith(incomplete):
-        #         yield event_id, f"Details for Event with id {event_id}"
 
     # TODO add support for zip code city state etc.
     def site_completion(
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        """Completion for sites.
+
+        Args:
+            incomplete (str): The last partial or full command before completion invoked.
+            args (List[str], optional): The previous arguments/commands on CLI. Defaults to None.
+
+        Yields:
+            Generator[Tuple[str, str], None, None]: Name and help_text for the site, or
+                Returns None if config is invalid
+        """
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_site_identifier(
             incomplete.replace('"', "").replace("'", ""),
             completion=True,
@@ -1030,7 +1204,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_template_identifier(
             incomplete,
             completion=True,
@@ -1048,7 +1227,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_template_identifier(
             incomplete,
             completion=True,
@@ -1071,7 +1255,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_dev_identifier(
             incomplete,
             completion=True,
@@ -1093,7 +1282,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str] = None,
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         match = self.get_dev_identifier(
             incomplete,
             dev_type=["gw", "switch"],
@@ -1117,7 +1311,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         if args[-1].lower() == "site":
             out = [m for m in self.site_completion(incomplete)]
             for m in out:
@@ -1140,7 +1339,12 @@ class Cache:
         self,
         incomplete: str,
         args: List[str],
-    ):
+    ) -> Generator[Tuple[str, str], None, None] | None:
+        # Prevents exception during completion when config missing or invalid
+        if not config.valid:
+            err_console.print(":warning:  Invalid config")
+            return
+
         cache = ()
         if [True for m in DEV_COMPLETION if args[-1].endswith(m)]:
             cache += tuple(["dev"])
@@ -1875,7 +2079,7 @@ class Cache:
                         kwargs["inv_db"] = True
                     else:
                         _word = " "
-                    typer.secho(f"No Match Found for {query_str}, Updating Device{_word}Cache", fg="red")
+                    print(f"[bright_red]No Match Found[/] for [cyan]{query_str}[/], Updating Device{_word}Cache.")
                     self.check_fresh(refresh=True, **kwargs)
 
             if match:

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -923,6 +923,15 @@ class CentralApi(Session):
 
     # TODO deprecate this used by group cache update.  _get_group_names then get_groups_properties.  More info in single call
     async def get_all_groups(self) -> Response:
+        """Get template group details for all groups.
+
+        This method will first call configuration/v2/groups to get a list of group names.
+        Then /configuration/v2/groups/template_info to get the template details (template_group or not)
+        for each group.
+
+        Returns:
+            Response: centralcli Response Object
+        """
         resp = await self._get_group_names()
         if not resp.ok:
             return resp
@@ -5623,6 +5632,46 @@ class CentralApi(Session):
     async def kms_get_health(self) -> Response:
         url = "/keymgmt/v1/health"
         return await self.get(url)
+
+    async def get_user_accounts(
+        self,
+        app_name: str = None,
+        type: str = None,
+        status: str = None,
+        order_by: str = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> Response:
+        """List user accounts.
+
+        Args:
+            app_name (str, optional): Appname nms to filter Aruba Central users, and account_setting
+                to filter HPE GreenLake Edge to Cloud Platform (CCS) application users  Valid
+                Values: nms, account_setting
+            type (str, optional): Filter based on system or federated user  Valid Values: system,
+                federated
+            status (str, optional): Filter user based on status (inprogress, failed)  Valid Values:
+                inprogress, failed
+            order_by (str, optional): Sort ordering (ascending or descending). +username signifies
+                ascending order of username.  Valid Values: +username, -username
+            offset (int, optional): Zero based offset to start from Defaults to 0.
+            limit (int, optional): Maximum number of items to return Defaults to 100.
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = "/platform/rbac/v1/users"
+
+        params = {
+            'app_name': app_name,
+            'type': type,
+            'status': status,
+            'order_by': order_by,
+            'offset': offset,
+            'limit': limit
+        }
+
+        return await self.get(url, params=params)
 
 if __name__ == "__main__":
     pass

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -18,6 +18,7 @@ from pycentral.base_utils import tokenLocalStoreUtil
 
 from . import (ArubaCentralBase, MyLogger, cleaner, config, constants, log,
                models, utils)
+from .utils import Mac
 from .response import Response, Session
 # buried import: requests is imported in add_template as a workaround until figure out aiohttp form data
 
@@ -572,7 +573,7 @@ class CentralApi(Session):
 
     async def get_client_details(
         self,
-        mac: utils.Mac,
+        mac: Mac,
         dev_type: str = None,
         # sort_by: str = None,
         **kwargs

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -735,9 +735,30 @@ def sort_result_keys(data: List[dict], order: List[str] = None) -> List[dict]:
     return data
 
 
-def get_devices(data: Union[List[dict], dict], sort: str = None) -> Union[List[dict], dict]:
+# TODO default verbose back to False once show device commands adapted to use --inventory so -v can be used for verbosity
+def get_devices(data: Union[List[dict], dict], verbose: bool = True,) -> Union[List[dict], dict]:
     data = utils.listify(data)
 
+    if not verbose:
+        non_verbose_keys = [
+                    "name",
+                    "status",
+                    "client_count",
+                    "type",
+                    "model",
+                    "ip_address",
+                    "macaddr",
+                    "serial",
+                    "group_name",
+                    "site",
+                    "labels",
+                    "uptime",
+                    "cpu_utilization",
+                    "mem_total",
+                    "mem_free",
+                    "firmware_version",
+        ]
+        data = [{k: v for k, v in inner.items() if k in non_verbose_keys} for inner in data]
     # gather all keys from all dicts in list each dict could potentially be a diff size
     # Also concats ip/mask if provided in sep fields
     data = sort_result_keys(data)

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -734,7 +734,7 @@ def unarchive(
 @app.command(hidden=True)
 def enable(
     what: EnableDisableArgs = typer.Argument("auto-sub"),
-    services: List[cli.cache.LicenseTypes] = typer.Argument(..., show_default=False),
+    services: List[cli.cache.LicenseTypes] = typer.Argument(..., show_default=False),  # type: ignore
     yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
@@ -770,7 +770,7 @@ def enable(
 @app.command(hidden=True)
 def disable(
     what: EnableDisableArgs = typer.Argument("auto-sub"),
-    services: List[cli.cache.LicenseTypes] = typer.Argument(..., show_default=False),
+    services: List[cli.cache.LicenseTypes] = typer.Argument(..., show_default=False),  # type: ignore
     yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -43,7 +43,7 @@ except (ImportError, ModuleNotFoundError) as e:
 
 from centralcli.cache import CentralObject  # noqa
 from centralcli.central import CentralApi  # noqa
-from centralcli.constants import (BlinkArgs, BounceArgs, IdenMetaVars, StartArgs, ResetArgs, EnableDisableArgs)  #noqa
+from centralcli.constants import (BlinkArgs, BounceArgs, IdenMetaVars, StartArgs, ResetArgs, EnableDisableArgs,)  #noqa
 
 iden = IdenMetaVars()
 
@@ -71,11 +71,8 @@ app.add_typer(clikick.app, name="kick",)
 app.add_typer(cliset.app, name="set",)
 
 
-@app.command(
-    help="Move device(s) to a defined group and/or site.",
-)
-
-# TODO Make this a sub command climove
+# TODO see if can change kw1 to "group" kw2 to "site" and unhide
+@app.command()
 def move(
     device: List[str, ] = typer.Argument(None, metavar=iden.dev_many, autocompletion=cli.cache.dev_kwarg_completion),
     kw1: str = typer.Argument(
@@ -88,6 +85,7 @@ def move(
         None,
         metavar="[site <SITE>]",
         show_default=False,
+        hidden=False,
     ),
     kw2: str = typer.Argument(
         None,
@@ -100,6 +98,7 @@ def move(
         metavar="[group <GROUP>]",
         show_default=False,
         help="[site and/or group required]",
+        hidden=False,
     ),
     _group: str = typer.Option(
         None,
@@ -129,6 +128,8 @@ def move(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ) -> None:
+    """Move device(s) to a defined group and/or site.
+    """
     central = cli.central
     console = Console()
 

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from time import sleep
 from typing import List
+import typer
 import asyncio
 
 from rich import print
@@ -18,7 +19,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     hook_enabled = False
 
-import typer
+err_console = Console(stderr=True)
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
@@ -40,9 +41,9 @@ except (ImportError, ModuleNotFoundError) as e:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.cache import CentralObject
+from centralcli.cache import CentralObject  # noqa
 from centralcli.central import CentralApi  # noqa
-from centralcli.constants import (BlinkArgs, BounceArgs, IdenMetaVars, StartArgs, ResetArgs, EnableDisableArgs)
+from centralcli.constants import (BlinkArgs, BounceArgs, IdenMetaVars, StartArgs, ResetArgs, EnableDisableArgs)  #noqa
 
 iden = IdenMetaVars()
 
@@ -73,6 +74,8 @@ app.add_typer(cliset.app, name="set",)
 @app.command(
     help="Move device(s) to a defined group and/or site.",
 )
+
+# TODO Make this a sub command climove
 def move(
     device: List[str, ] = typer.Argument(None, metavar=iden.dev_many, autocompletion=cli.cache.dev_kwarg_completion),
     kw1: str = typer.Argument(
@@ -848,6 +851,8 @@ def convert(
 
 
 def all_commands_callback(ctx: typer.Context, update_cache: bool):
+    if ctx.resilient_parsing:
+        config.is_completion = True
     if not ctx.resilient_parsing:
         version, account, debug, debugv, default, update_cache = None, None, None, None, None, None
         for idx, arg in enumerate(sys.argv[1:]):
@@ -860,10 +865,10 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
             elif arg == "-d":
                 default = True
             elif arg == "--account" and "-d" not in sys.argv:
-                account = sys.argv[idx + 1]
+                account = sys.argv[idx + 2]  # sys.argv enumeration is starting at index 1 so need to adjust idx by 2 for next arg
             elif arg == "-U":
                 update_cache = True
-            elif arg.startswith("-") and not arg.startswith("--"):
+            elif arg.startswith("-") and not arg.startswith("--"):  # -dU is allowed
                 if "d" in arg:
                     default = True
                 if "U" in arg:
@@ -876,7 +881,11 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
             cli.version_callback(ctx)
             raise typer.Exit(0)
         if default:
-            default = cli.default_callback(ctx, True)
+            if "--account " in str(sys.argv) and account not in ["central_info", "default"]:
+                err_console.print(f":warning:  Both [cyan]-d[/] and [cyan]--account[/] flag used.  Honoring [cyan]-d[/], ignoring account [cyan]{account}[/]")
+                account = config.default_account
+            cli.account_name_callback(ctx, account=config.default_account, default=True)
+            # default = cli.default_callback(ctx, True)
         # elif account:
         else:
             cli.account_name_callback(ctx, account=account)
@@ -896,7 +905,7 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
 @app.callback()
 def callback(
     # ctx: typer.Context,``
-    version: bool = typer.Option(False, "--version", "-V", "-v", case_sensitive=False, is_flag=True, help="Show current cencli version, and latest available version."),
+    version: bool = typer.Option(False, "--version", "-V", "-v", case_sensitive=False, is_flag=True, help="Show current cencli version, and latest available version.",),
     debug: bool = typer.Option(False, "--debug", is_flag=True, envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
                             #    callback=all_commands_callback),
     debugv: bool = typer.Option(False, "--debugv", is_flag=True, help="Enable Verbose Debug Logging", hidden=True,),
@@ -908,10 +917,12 @@ def callback(
         help="Use default central account",
         show_default=False,
     ),
-    account: str = typer.Option("central_info",
-                                envvar="ARUBACLI_ACCOUNT",
-                                help="The Aruba Central Account to use (must be defined in the config)",
-                                autocompletion=cli.cache.account_completion),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
     update_cache: bool = typer.Option(False, "-U", hidden=True, lazy=True, callback=all_commands_callback),
 ) -> None:
     """

--- a/centralcli/cliassign.py
+++ b/centralcli/cliassign.py
@@ -28,7 +28,7 @@ app = typer.Typer()
 # TODO update cache for device after successful assignment
 @app.command()
 def license(
-    license: cli.cache.LicenseTypes = typer.Argument(..., show_default=False),
+    license: cli.cache.LicenseTypes = typer.Argument(..., show_default=False),  # type: ignore
     serial_nums: List[str] = typer.Argument(..., help="device serial numbers or 'auto' to enable auto-subscribe.", show_default=False),
     yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),

--- a/centralcli/clicaas.py
+++ b/centralcli/clicaas.py
@@ -33,7 +33,6 @@ import sys
 from rich import print
 import typer
 from typing import List
-from rich.console import Console
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:

--- a/centralcli/clicaas.py
+++ b/centralcli/clicaas.py
@@ -305,7 +305,6 @@ def send_cmds(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 callback=cli.account_name_callback),
 ) -> None:
-    console = Console(emoji=False)
     yes = yes if yes else yes_
     commands = commands or []
     if kw1 == "group":
@@ -376,7 +375,7 @@ def send_cmds(
         batch_res = cli.central.batch_request(_reqs)
         cli.display_results(batch_res, cleaner=cleaner.parse_caas_response)
         # caas.
-        # Rich progress bar here
+        # TODO Rich progress bar here
 
 
 @app.callback()

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -71,7 +71,7 @@ class CLICommon:
             msg = (
                 f'[magenta]Using Account:[/] [cyan]{self.account}[/].\n'
                 f'[bright_red blink]Account setting is sticky.[/]  '
-                '[magenta]will be used for subsequent commands until[/]\n'
+                f'[cyan]{self.account}[/] [magenta]will be used for subsequent commands until[/]\n'
                 f'[cyan]--account <account name>[/] or [cyan]-d[/] (revert to default). is used.\n'
             )
             return msg
@@ -100,7 +100,7 @@ class CLICommon:
 
         @property
         def previous_short(self):
-            return f":information:  Using previously specified account: [bright_green]{self.account}[/]."
+            return f":information:  Using previously specified account: [bright_green]{self.account}[/].\n"
 
     def account_name_callback(self, ctx: typer.Context, account: str, default: bool = False) -> str:
         """Responsible for account messaging.  Actual account is determined in config.
@@ -188,10 +188,10 @@ class CLICommon:
 
             if account not in ["central_info", "default"]:
                 if config.defined_accounts:
-                    console.print(f"[bright_green]The following accounts are defined[/] [cyan]{'[/], [cyan]'.join(config.defined_accounts)}[reset]")
+                    console.print(f"[bright_green]The following accounts are defined[/] [cyan]{'[/], [cyan]'.join(config.defined_accounts)}[reset]\n")
                     if not _def_msg:
                         console.print(
-                            "The default account [cyan]central_info[/] is used if no account is specified via [cyan]--account[/] flag.\n"
+                            f"The default account [cyan]{config.default_account}[/] is used if no account is specified via [cyan]--account[/] flag.\n"
                             "or the [cyan]ARUBACLI_ACCOUNT[/] environment variable.\n"
                         )
 

--- a/centralcli/clirefresh.py
+++ b/centralcli/clirefresh.py
@@ -3,22 +3,25 @@
 
 import typer
 import sys
+import asyncio
 from pathlib import Path
+from typing import List
 
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import cli, utils
+    from centralcli import cli, utils, config
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import cli, utils
+        from centralcli import cli, utils, config
     else:
         print(pkg_dir.parts)
         raise e
 
 from centralcli.central import CentralApi  # noqa
+from rich.console import Console
 
 app = typer.Typer()
 
@@ -27,6 +30,13 @@ tty = utils.tty
 
 @app.command(short_help="Refresh access token")
 def token(
+    account_list: List[str] = typer.Argument(
+        None,
+        help="A list of accounts to refresh tokens for (must be defined in the config).  This is useful automated for cron/task-scheduler refresh.",
+        autocompletion=cli.cache.account_completion,
+        show_default=False,
+    ),
+    all: bool = typer.Option(False, "-A", "--all", help="Refresh Tokens for all defined workspaces in config.",),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Debug Logging", callback=cli.debug_callback),
     account: str = typer.Option(
@@ -39,8 +49,44 @@ def token(
     """Refresh Central API access/refresh tokens.
 
     This is not necessary under normal circumstances as the cli will automatically refresh the tokens if they are expired.
+    This can be useful for automated runs via cron/task-scheduler.  Ensuring the access token does not expire even if the
+    cli is not used.
     """
-    cli.central.refresh_token()
+    # TODO expand help text to include URL with example
+    if not all and not account_list:
+        cli.central.refresh_token()
+    else:
+        console = Console()
+        if account_list:
+            verified_account_list = []
+            for account in account_list:
+                if account in config.defined_accounts:
+                    verified_account_list += [account]
+                else:
+                    console.print(f":warning:  Ignoring account {account} as it's not defined in the config.")
+                    console.print(f"  [italic]Update config @ {config.file}[/]")
+            if len(verified_account_list) != len(account_list):
+                console.print(f"Performing token refresh for {len(verified_account_list)} of {len(account_list)} provided accounts.")
+
+            account_list = [config.default_account,  *verified_account_list]
+        else:
+            account_list = [config.default_account,  *config.defined_accounts]
+
+        async def refresh_multi(account_list: List[str]):
+            success_list = await asyncio.gather(*[
+                asyncio.to_thread(CentralApi(account_name=account).refresh_token, silent=True)
+                for account in account_list
+                ]
+            )
+
+            return success_list
+
+        with console.status(f"Refreshing Tokens for {len(account_list)} accounts defined in config", spinner="runner",):
+            success_list = asyncio.run(refresh_multi(account_list))
+
+        for account, success in zip(account_list, success_list):
+            console.print(f"{':x:' if not success else ':heavy_check_mark:'}  {account}")
+        console.print(f"\nSuccessfully refreshed tokens for {success_list.count(True)} of {len(success_list)} accounts.")
 
 @app.command(short_help="Refresh local cache")
 def cache(

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -1473,7 +1473,7 @@ def config_(
     if group_dev == "cencli":  # Hidden show cencli config
         return _get_cencli_config()
 
-    group_dev = cli.cache.get_identifier(group_dev, ["group", "dev"], device_type=["ap", "gw"])
+    group_dev: CentralObject = cli.cache.get_identifier(group_dev, ["group", "dev"], device_type=["ap", "gw"])
     if group_dev.is_group:
         group = group_dev
         if device:

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -869,7 +869,7 @@ def dhcp(
         show_default=False,
     ),
 ) -> None:
-    """"Show DHCP pool or lease details (gateways only)"
+    """Show DHCP pool or lease details (gateways only)
     """
     central = cli.central
     dev: CentralObject = cli.cache.get_dev_identifier(dev, dev_type="gw")

--- a/centralcli/clishowtshoot.py
+++ b/centralcli/clishowtshoot.py
@@ -2,41 +2,30 @@
 # -*- coding: utf-8 -*-
 
 import typer
-import time
-import pendulum
-import asyncio
 import sys
-from typing import List, Union
 from pathlib import Path
 from rich import print
 from rich.console import Console
 
-try:
-    import psutil
-    hook_enabled = True
-except (ImportError, ModuleNotFoundError):
-    hook_enabled = False
-
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import cleaner, cli, utils
+    from centralcli import cleaner, cli
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import cleaner, cli, utils
+        from centralcli import cleaner, cli
     else:
         print(pkg_dir.parts)
         raise e
 
 from centralcli.constants import (
-    IdenMetaVars, DevTypes, SortTsCmdOptions, TSDevTypes, lib_to_api  # noqa
+    IdenMetaVars, SortTsCmdOptions, TSDevTypes, lib_to_api  # noqa
 )
 
 app = typer.Typer()
 
-tty = utils.tty
 iden_meta = IdenMetaVars()
 
 
@@ -47,10 +36,12 @@ def results(
         metavar=iden_meta.dev,
         help="Aruba Central Device",
         autocompletion=cli.cache.dev_completion,
+        show_default=False,
     ),
     session_id: str = typer.Argument(
         None,
         help="The troubleshooting session id.",
+        show_default=False,
     ),
     verbose2: bool = typer.Option(
         False,
@@ -151,7 +142,6 @@ def commands(
     if sort_by == "id":
         sort_by = None
     central = cli.central
-    con = Console(emoji=False)
     dev_type = lib_to_api("tshoot", device_type)
 
     resp = central.request(central.get_ts_commands, device_type=dev_type,)

--- a/centralcli/clitest.py
+++ b/centralcli/clitest.py
@@ -123,9 +123,12 @@ def method(
         raise typer.Exit(1)
 
     if _help:
-        old_ret = "Response: CentralAPI Response object"
-        new_ret = "Response from Aruba Central API gateway."
-        print(getattr(central, method).__doc__.replace(old_ret, new_ret))
+        if getattr(central, method).__doc__:
+            old_ret = "Response: CentralAPI Response object"
+            new_ret = "Response from Aruba Central API gateway."
+            print(getattr(central, method).__doc__.replace(old_ret, new_ret))
+        else:
+            print(f"Sorry, {getattr(central, method).__name__}, lacks a docstr.  No help.")
         raise typer.Exit(0)
 
     kwargs = kwargs or {}

--- a/centralcli/clitshoot.py
+++ b/centralcli/clitshoot.py
@@ -254,7 +254,7 @@ def dpi(
 
 
 @app.command()
-def ap_ssid(
+def ssid(
     device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_ap_completion, show_default=False,),
     outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),

--- a/centralcli/clitshoot.py
+++ b/centralcli/clitshoot.py
@@ -57,7 +57,10 @@ def send_cmds_by_id(device: CentralObject, commands: List[int], pager: bool = Fa
 
             if ts_resp.output.get("status", "") == "COMPLETED":
                 lines = "\n".join([line for line in ts_resp.output["output"].splitlines() if line != " "])
-                print(lines) if not cli.raw_out else print(ts_resp.output["output"])
+                # print(lines) if not cli.raw_out else print(ts_resp.output["output"])
+                ts_resp.raw = ts_resp.output["output"]
+                ts_resp.output = lines
+                cli.display_results(ts_resp, pager=pager, outfile=outfile)
                 complete = True
                 break
             else:
@@ -82,7 +85,7 @@ def ap_overlay(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ):
-    """Show AP Overlay details
+    """Show AP Overlay details (Tunneled SSIDs)
 
     [cyan]Returns the output of the following commands useful in troubleshooting overlay AP / gateway tunnels.[/]
 
@@ -92,6 +95,32 @@ def ap_overlay(
     """
     dev = cli.cache.get_dev_identifier(device, dev_type=("ap"))
     commands = [201, 203, 218]
+    send_cmds_by_id(dev, commands=commands, pager=pager, outfile=outfile)
+
+
+@app.command()
+def gw_overlay(
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_gw_completion, show_default=False,),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                autocompletion=cli.cache.account_completion),
+):
+    """Show GW Overlay details (Tunneled SSIDs)
+
+    [cyan]Returns the output of the following commands useful in troubleshooting overlay AP / gateway tunnels.[/]
+
+    [cyan]-[/] show crypto oto
+    [cyan]-[/] show tunnelmgr tunnel-list
+    [cyan]-[/] show tunnelmgr countersshow run
+
+    """
+    dev = cli.cache.get_dev_identifier(device, dev_type=("gw"))
+    commands = [2453, 2454, 2455]
     send_cmds_by_id(dev, commands=commands, pager=pager, outfile=outfile)
 
 
@@ -119,6 +148,31 @@ def ap_dpi(
     """
     dev = cli.cache.get_dev_identifier(device, dev_type=("ap"))
     commands = [190, 210, 211, 317, 318]
+    send_cmds_by_id(dev, commands=commands, pager=pager, outfile=outfile)
+
+
+@app.command()
+def ap_show_tech(
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_ap_completion, show_default=False,),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
+    account: str = typer.Option("central_info",
+                                envvar="ARUBACLI_ACCOUNT",
+                                help="The Aruba Central Account to use (must be defined in the config)",
+                                autocompletion=cli.cache.account_completion),
+):
+    """Show DPI (valid on APs)
+
+    [cyan]Returns the output of the following DPI related commands.[/]
+
+    [cyan]-[/] show tech-support
+    [cyan]-[/] show tech-support supplemental
+    [cyan]-[/] show tech-support memory
+    """
+    dev = cli.cache.get_dev_identifier(device, dev_type=("ap"))
+    commands = [115, 369, 465]
     send_cmds_by_id(dev, commands=commands, pager=pager, outfile=outfile)
 
 

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -203,15 +203,6 @@ class NotifyToArgs(str, Enum):
     email = "email"
 
 
-class ClientArgs(str, Enum):
-    wired = "wired"
-    wireless = "wireless"
-    all = "all"
-    mac = "mac"
-    device = "device"
-    denylisted = "denylisted"
-
-
 class RefreshWhat(str, Enum):
     cache = "cache"
     token = "token"

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -362,11 +362,7 @@ def output(
         outdata = utils.unlistify(outdata)
         # TODO custom yaml Representer
         raw_data = yaml.dump(json.loads(json.dumps(outdata, cls=Encoder)), sort_keys=False)
-        # _lexer = lexers.YamlLexer
-        console = Console(record=True, emoji=False)
-        console.begin_capture()
-        console.print(raw_data)
-        table_data = console.end_capture()
+        table_data = rich_capture(raw_data)
 
     elif tablefmt == "csv":
         csv_data = "\n".join(
@@ -398,6 +394,8 @@ def output(
             else:  # template / config file output
                 # get rid of double nl @ EoF (configs)
                 raw_data = table_data = "{}\n".format('\n'.join(outdata).rstrip('\n'))
+                table_data = rich_capture(raw_data)
+
         else:
             raw_data = table_data = '\n'.join(outdata)
             # Not sure what hit's this, but it was created so something must

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -508,7 +508,6 @@ class Session():
                     _ -= 1
                 else:
                     break
-                spin_txt_run = f'{spin_txt_run} {spin_txt_retry}'  # FIXME after 503 (or any others above) spin txt didn't reflect retry
             else:
                 if resp.rl.near_sec:
                     self.rl_log += [

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import asyncio
 import json
 import os
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "3.0.0"
+version = "4.0.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -14,7 +14,7 @@ runner = CliRunner()
 
 
 def test_add_group1():
-    result = runner.invoke(app, ["add", "group",  "cencli_test_group1", "-Y"])
+    result = runner.invoke(app, ["-d", "add", "group",  "cencli_test_group1", "-Y"])
     assert True in [
         result.exit_code == 0 and "Created" in result.stdout,
         result.exit_code == 1 and "already exists" in result.stdout
@@ -22,7 +22,7 @@ def test_add_group1():
 
 
 def test_add_group2_wired_tg():
-    result = runner.invoke(app, ["add", "group",  "cencli_test_group2", "--sw", "--wired-tg", "-Y"])
+    result = runner.invoke(app, ["-d", "add", "group",  "cencli_test_group2", "--sw", "--wired-tg", "-Y"])
     assert True in [
         result.exit_code == 0 and "Created" in result.stdout,
         result.exit_code == 1 and "already exists" in result.stdout
@@ -30,7 +30,7 @@ def test_add_group2_wired_tg():
 
 
 def test_add_group3_wlan_tg():
-    result = runner.invoke(app, ["add", "group",  "cencli_test_group3", "--ap", "--wlan-tg", "-Y"])
+    result = runner.invoke(app, ["-d", "add", "group",  "cencli_test_group3", "--ap", "--wlan-tg", "-Y"])
     assert True in [
         result.exit_code == 0 and "Created" in result.stdout,
         result.exit_code == 1 and "already exists" in result.stdout
@@ -38,7 +38,7 @@ def test_add_group3_wlan_tg():
 
 
 def test_add_group4_aos10_gw_wlan():
-    result = runner.invoke(app, ["add", "group",  "cencli_test_group4", "--ap", "--gw", "--aos10", "--gw-role", "wlan", "-Y"])
+    result = runner.invoke(app, ["-d", "add", "group",  "cencli_test_group4", "--ap", "--gw", "--aos10", "--gw-role", "wlan", "-Y"])
     assert True in [
         result.exit_code == 0 and "Created" in result.stdout,
         result.exit_code == 1 and "already exists" in result.stdout

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -24,7 +24,7 @@ def cleanup():
     yield do_nothing()
     # executed after test is run
     result = runner.invoke(app, ["show", "cache", "groups", "--json"])
-    del_groups = [g for g in json.loads(result.stdout) if g.startswith("cencli_test_")]
+    del_groups = [g for g in json.loads(result.stdout) if g.startswith("cencli_test_") or g == "TESTING"]
     if del_groups:
         result = runner.invoke(app, ["delete", "group", *del_groups, "-Y"])
         assert "Success" in result.stdout
@@ -70,11 +70,11 @@ def test_blink_wrong_dev_type():
 
 
 def test_clone_group(cleanup):
-    result = runner.invoke(app, ["clone", "group", TEST_DEVICES["gateway"]["group"], TEST_DEVICES["clone"]["to_group"], "-Y"])
+    result = runner.invoke(app, ["-d", "clone", "group", TEST_DEVICES["gateway"]["group"], TEST_DEVICES["clone"]["to_group"], "-Y"])
     assert result.exit_code == 0
     assert "201" in result.stdout
     assert "Created" in result.stdout
-    cleanup()
+    # cleanup()
 
 
 # def test_do_move_dev_to_group():

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -281,19 +281,25 @@ def test_show_clients():
 
 
 def test_show_clients_wireless():
-    result = runner.invoke(app, ["show", "clients", "wireless"],)
+    result = runner.invoke(app, ["show", "clients", "--wireless"],)
     assert result.exit_code == 0
     assert "All Wireless Clients" in result.stdout
     assert "mac" in result.stdout
 
 
+def test_show_clients_wired():
+    result = runner.invoke(app, ["show", "clients", "--wired"],)
+    assert result.exit_code == 0
+    assert "All Wired Clients" in result.stdout
+    assert "mac" in result.stdout
+
+
 def test_show_client_by_mac():
     TEST_DEVICES["client_mac"] = TEST_DEVICES.get("client_mac", TEST_DEVICES["wlan_client_mac"])
-    result = runner.invoke(app, ["show", "clients", "mac", TEST_DEVICES["client_mac"]],)
-    assert TEST_DEVICES["client_mac"] == result.stdout.splitlines()[5].split()[1]
+    result = runner.invoke(app, ["show", "clients", TEST_DEVICES["client_mac"]],)
     assert result.exit_code == 0
-    assert "client with MAC" in result.stdout
-    assert "mac" in result.stdout
+    assert "role" in result.stdout
+    assert f"mac: {TEST_DEVICES['wlan_client_mac']}" in result.stdout
 
 
 def test_show_group_level_config():


### PR DESCRIPTION

💥 Breaking Change.  Change `cencli show clients`, options/filters/arguments have changed. See `cencli show clients --help`
✨ Add additional options to `cencli refresh token` Now supports a list of accounts to refresh, as well as an `--all` flag to update tokens for all defined accounts.
✨ Add show run support for CX (uses troubleshooting commands).
✨ Restore account messaging.
💬 Prevent exception in `cencli test method` when `--doc` option is used, but method has no docstr.
💬  Provide spinner when rendering output (useful for large clusters).
✨ Provide msg to stderr when tab completion attempted with no or invalid config, prevent Exception.
💡 Update docstrs and type hints in config.py, central.py
✨ Add method get_user_accounts to get GLCP users.  (Not used by CLI yet)
🚧 WIP: Add non-verbose / default field list for `show <device type|all>`.
💬 Simplify `tshoot ap-ssid` to `tshoot ssid` to be consistent with other commands.
🐛 Fix `--out` not being honored in all tshoot commands
✨ Add numerous new troubleshooting commands.
✅ update do_ tests to clean up cloned group on tear-down
🐛 fix get_identifier to return matches for all qry_funcs when completion=True