### PR TITLE
🔖 v5.0.0

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -1725,7 +1725,7 @@ class Cache:
                 self.GroupDB.truncate()
                 update_res = self.GroupDB.insert_multiple(resp.output)
                 if False in update_res:
-                    log.error("Tiny DB returned an error during group db update")
+                    log.error("Tiny DB returned an error during group db update", caption=True)
             return resp
 
     async def update_label_db(self, data: Union[list, dict] = None, remove: bool = False) -> Union[List[int], Response]:

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -308,7 +308,7 @@ class Cache:
             self.EventDB: Table = self.DevDB.table("events")
             self.HookConfigDB: Table = self.DevDB.table("wh_config")
             self.HookDataDB: Table = self.DevDB.table("wh_data")
-            self.MpskDB: Table = self.DevDB.table("mpsk")  # Only updated when show mpsk-networks is ran or as needed when show named-mpsk <SSID> is ran
+            self.MpskDB: Table = self.DevDB.table("mpsk")  # Only updated when show mpsk networks is ran or as needed when show named-mpsk <SSID> is ran
             self._tables = [self.DevDB, self.InvDB, self.SiteDB, self.GroupDB, self.TemplateDB, self.LabelDB, self.LicenseDB, self.ClientDB]
             self.Q = Query()
             if data:

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -14,6 +14,7 @@ from rich import print
 from rich.console import Console
 from tinydb import Query, TinyDB
 from tinydb.table import Table
+from copy import deepcopy
 
 from centralcli import CentralApi, Response, cleaner, config, constants, log, models, render, utils
 
@@ -865,6 +866,9 @@ class Cache:
                 Returns None if config is invalid
         """
         # Prevents exception during completion when config missing or invalid
+        from rich import inspect
+        inspect(ctx, console=err_console)
+        inspect(ctx.params)
         if not config.valid:
             err_console.print(":warning:  Invalid config")
             return
@@ -1504,7 +1508,7 @@ class Cache:
 
     # FIXME handle no devices in Central yet exception 837 --> cleaner.py 498
     # TODO if we are updating inventory we only need to get those devices types
-    async def update_dev_db(self,  data: Union[str, List[str], List[dict]] = None, remove: bool = False) -> Union[List[int], Response]:
+    async def update_dev_db(self,  data: Union[str, List[str], List[dict]] = None, remove: bool = False, **kwargs) -> Union[List[int], Response]:
         """Update Device Database (local cache).
 
         Args:
@@ -1557,10 +1561,10 @@ class Cache:
                     log.error(f"Tiny DB returned an error during DevDB update {db_res}", show=True)
         else:
             # TODO update device inventory first then only get details for device types in inventory
-            resp = await self.central.get_all_devicesv2()
+            resp = await self.central.get_all_devicesv2(**kwargs)
             if resp.ok:
                 if resp.output:
-                    _update_data = utils.listify(resp.output)
+                    _update_data = utils.listify(deepcopy(resp.output))
                     _update_data = cleaner.get_devices(_update_data, cache=True)
                     _update_data = await self.get_swack_ids(resp, _update_data)
 

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2093,7 +2093,7 @@ class Cache:
     def get_dev_identifier(
         self,
         query_str: str | Iterable[str],
-        dev_type: constants.GenericDevTypes | List[constants.GenericDevTypes] = None,
+        dev_type: constants.AllDevTypes | List[constants.AllDevTypes] = None,
         swack: bool = False,
         conductor_only: bool = False,
         retry: bool = True,
@@ -2108,7 +2108,7 @@ class Cache:
 
         Args:
             query_str (str | Iterable[str]): The query string or list of strings to attempt to match.
-            dev_type (constants.GenericDevTypes | List[constants.GenericDevTypes], optional): Limit matches to specific device type. Defaults to None (all device types).
+            dev_type (constants.AllDevTypes | List[constants.AllDevTypes], optional): Limit matches to specific device type. Defaults to None (all device types).
             swack (bool, optional): For switches only return the conductor switch that matches. For APs only return the VC of the swarm the match belongs to. Defaults to False.
                 If swack=True devices that lack a swack_id (swarm_id | stack_id) are filtered (even if they match).
             conductor_only (bool, optional): Similar to swack, but only filters member switches of stacks, but will also return any standalone switches that match.
@@ -2203,9 +2203,12 @@ class Cache:
         if dev_type:
             all_match = match.copy()
             dev_type = utils.listify(dev_type)
+            if "switch" in dev_type:
+                dev_type = set(filter(lambda t: t != "switch", [*dev_type, "cx", "sw"]))
             match = []
+
             for _dev_type in dev_type:
-                match += [d for d in all_match if d.generic_type.lower() in "".join(_dev_type[0:len(d.generic_type)]).lower()]
+                match += [d for d in all_match if d.type == _dev_type]
 
         # swack is swarm/stack id.  We filter out all but the commander for a stack and all but the VC for a swarm
         # For a stack a multi-match is expected when they are using hostname as all members have the same hostname.

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2216,10 +2216,8 @@ class Cache:
             dev_type = utils.listify(dev_type)
             if "switch" in dev_type:
                 dev_type = set(filter(lambda t: t != "switch", [*dev_type, "cx", "sw"]))
-            match = []
 
-            for _dev_type in dev_type:
-                match += [d for d in all_match if d.type == _dev_type]
+            match = [d for d in all_match if d.type in dev_type]
 
         # swack is swarm/stack id.  We filter out all but the commander for a stack and all but the VC for a swarm
         # For a stack a multi-match is expected when they are using hostname as all members have the same hostname.

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2090,6 +2090,7 @@ class Cache:
         self,
         query_str: str | Iterable[str],
         dev_type: constants.GenericDevTypes | List[constants.GenericDevTypes] = None,
+        swack: bool = False,
         retry: bool = True,
         completion: bool = False,
         silent: bool = False,
@@ -2177,6 +2178,13 @@ class Cache:
             match = []
             for _dev_type in dev_type:
                 match += [d for d in all_match if d.generic_type.lower() in "".join(_dev_type[0:len(d.generic_type)]).lower()]
+
+        # swack is swarm/stack id.  We filter out all but the commander for a stack and all but the VC for a swarm
+        # For a stack a multi-match is expected when they are using hostname as all members have the same hostname.
+        # This param returns only the commander matching the name.
+        if swack and len(match) > 1:
+            unique_swack_ids = set([d.swack_id for d in match if d.swack_id])
+            match = [d for d in match if d.swack_id in unique_swack_ids and d.ip]
 
         if completion:
             return match or []

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2126,6 +2126,7 @@ class Cache:
         qry_funcs: Sequence[str],
         device_type: Union[str, List[str]] = None,
         swack: bool = False,
+        conductor_only: bool = False,
         group: str = None,
         all: bool = False,
         completion: bool = False,
@@ -2139,6 +2140,8 @@ class Cache:
                 Defaults to None.
             swack (bool, optional): Restrict matches to only the stack commanders matching query (filter member switches).
                 Defaults to False.
+            conductor_only (bool, optional): Similar to swack, but only filters member switches of stacks, but will also return any standalone switches that match.
+                Does not filter non stacks, the way swack option does. Defaults to False.
             group (str, optional): applies to get_template_identifier, Only match if template is in this group.
                 Defaults to None.
             all (bool, optional): For use in completion, adds keyword "all" to valid completion.
@@ -2164,6 +2167,7 @@ class Cache:
                 if q == "dev":
                     kwargs["dev_type"] = device_type
                     kwargs["swack"] = swack
+                    kwargs["conductor_only"] = conductor_only
                 elif q == "template":
                     kwargs["group"] = group
                 this_match = getattr(self, f"get_{q}_identifier")(qry_str, **kwargs) or []

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2019,6 +2019,7 @@ class Cache:
         qry_str: str,
         qry_funcs: Sequence[str],
         device_type: Union[str, List[str]] = None,
+        swack: bool = False,
         group: str = None,
         all: bool = False,
         completion: bool = False,
@@ -2030,6 +2031,8 @@ class Cache:
             qry_funcs (Sequence[str]): Sequence of strings "dev", "group", "site", "template"
             device_type (Union[str, List[str]], optional): Restrict matches to specific dev type(s).
                 Defaults to None.
+            swack (bool, optional): Restrict matches to only the stack commanders matching query (filter member switches).
+                Defaults to False.
             group (str, optional): applies to get_template_identifier, Only match if template is in this group.
                 Defaults to None.
             all (bool, optional): For use in completion, adds keyword "all" to valid completion.
@@ -2054,6 +2057,7 @@ class Cache:
                 kwargs = default_kwargs.copy()
                 if q == "dev":
                     kwargs["dev_type"] = device_type
+                    kwargs["swack"] = swack
                 elif q == "template":
                     kwargs["group"] = group
                 this_match = getattr(self, f"get_{q}_identifier")(qry_str, **kwargs) or []

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1417,7 +1417,7 @@ class CentralApi(Session):
         hostname: str = None,
         group: str = None,
         offset: int = 0,
-        limit: int = 100,
+        limit: int = 1000,
     ) -> Response:
         """List Switch Stacks.
 
@@ -1425,7 +1425,7 @@ class CentralApi(Session):
             hostname (str, optional): Filter by stack hostname
             group (str, optional): Filter by group name
             offset (int, optional): Pagination offset Defaults to 0.
-            limit (int, optional): Pagination limit. Default is 100 and max is 1000 Defaults to 100.
+            limit (int, optional): Pagination limit. Default is 1000 and max is 1000.
 
         Returns:
             Response: CentralAPI Response object
@@ -1440,6 +1440,22 @@ class CentralApi(Session):
         }
 
         return await self.get(url, params=params)
+
+    async def get_switch_stack_details(
+        self,
+        stack_id: str,
+    ) -> Response:
+        """Switch Stack Details.
+
+        Args:
+            stack_id (str): Filter by Switch stack_id
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = f"/monitoring/v1/switch_stacks/{stack_id}"
+
+        return await self.get(url)
 
     async def get_dev_details(
         self,

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1924,7 +1924,7 @@ class CentralApi(Session):
         primary_vlan_id: int = None,
         status: str = None,
         sort: str = None,
-        calculate_total: bool = None,
+        calculate_total: bool = True,
         aos_sw: bool = False,
         offset: int = 0,
         limit: int = 500,
@@ -1932,7 +1932,7 @@ class CentralApi(Session):
         """Get vlan info for switch (CX and SW).
 
         Args:
-            iden (str): Serial Number of Stack ID, Identifies the dev to return VLANs from.
+            iden (str): Serial Number or Stack ID, Identifies the dev to return VLANs from.
             stack (bool, optional): Set to True for stack. Default: False
             name (str, optional): Filter by vlan name
             id (int, optional): Filter by vlan id
@@ -1969,7 +1969,7 @@ class CentralApi(Session):
             "primary_vlan_id": primary_vlan_id,
             "status": status,
             "sort": sort,
-            "calculate_total": calculate_total,
+            "calculate_total": None if not calculate_total else str(calculate_total),  # sending str of False/false will be interpreted as true.  None will strip the param
             "offset": offset,
             "limit": limit,
         }
@@ -2146,13 +2146,15 @@ class CentralApi(Session):
 
         return await self.get(url)
 
-    async def get_switch_neighbors_v1(
+    async def get_cx_switch_neighbors(
         self,
         serial: str,
     ) -> Response:
         """Get lldp device neighbor info for CX switch.
 
         If used on AOS-SW will only return neighbors that are CX switches
+        For a stack this will return neighbors for the individual member
+        use get_cx_switch_stack_neighbors to get neighbors for entire stack
 
         Args:
             serial (str): id of the switch
@@ -2164,7 +2166,7 @@ class CentralApi(Session):
 
         return await self.get(url)
 
-    async def get_cx_switch_stack_neighbors_v1(
+    async def get_cx_switch_stack_neighbors(
         self,
         stack_id: str,
     ) -> Response:

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1518,6 +1518,24 @@ class CentralApi(Session):
 
         return await self.get(url, params=params)
 
+    async def get_wlan_cluster_by_group(
+        self,
+        group_name: str,
+        ssid: str
+    ) -> Response:
+        """Retrieve Cluster mapping for given group/SSID.
+
+        Args:
+            group_name (str): The name of the group.
+            ssid (str): Wlan ssid name
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = f"/overlay-wlan-config/v2/node_list/GROUP/{group_name}/config/ssid_cluster/{ssid}/WIRELESS_PROFILE/"
+
+        return await self.get(url)
+
     # TODO Under test 3/7/2024
     async def get_full_wlan_list(
         self,
@@ -3533,6 +3551,36 @@ class CentralApi(Session):
             'firmware_version': firmware_version,
             'reboot': reboot,
             'model': model
+        }
+
+        return await self.post(url, json_data=json_data)
+
+    async def cancel_upgrade(
+        self,
+        device_type: str,
+        serial: str = None,
+        swarm_id: str = None,
+        group: str = None,
+    ) -> Response:
+        """Cancel scheduled firmware upgrade.
+
+        Args:
+            device_type (str): Specify one of "cx|sw|ap|gw  (sw = aos-sw)"
+            serial (str): Serial of device
+            swarm_id (str): Swarm ID
+            group (str): Specify Group Name to cancel upgrade for devices in that group
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        device_type = constants.lib_to_api('firmware', device_type)
+        url = "/firmware/v1/upgrade/cancel"
+
+        json_data = {
+            'swarm_id': swarm_id,
+            'serial': serial,
+            'device_type': device_type,
+            'group': group
         }
 
         return await self.post(url, json_data=json_data)

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -5951,6 +5951,44 @@ class CentralApi(Session):
 
         return await self.get(url, params=params)
 
+    async def cloudauth_download_mpsk_csv(
+        self,
+        ssid: str,
+        filename: str = None,
+        name: str = None,
+        role: str = None,
+        status: str = None,
+        sort: str = None,
+    ) -> Response:
+        """Fetch all Named MPSK as a CSV file.
+
+        Args:
+            ssid (str): Configured MPSK SSID for which Named MPSKs are to be downloaded.
+            filename (str, optional): Suggest a file name for the downloading file via content
+                disposition header.
+            name (str, optional): Filter by name of the named MPSK. Does a 'contains' match.
+            role (str, optional): Filter by role of the named MPSK. Does an 'equals' match.
+            status (str, optional): Filter by status of the named MPSK. Does an 'equals' match.
+                Valid Values: enabled, disabled
+            sort (str, optional): Sort order  Valid Values: +name, -name, +role, -role, +status,
+                -status
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = "/cloudAuth/api/v2/download/mpsk"
+
+        params = {
+            'ssid': ssid,
+            'filename': filename,
+            'name': name,
+            'role': role,
+            'status': status,
+            'sort': sort
+        }
+
+        return await self.get(url, params=params)
+
     async def get_user_accounts(
         self,
         app_name: str = None,

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1145,7 +1145,7 @@ class CentralApi(Session):
         Args:
             serial (str): Switch serial
             port (str, optional): Filter by switch port
-            aos_sw (bool, optional): Device is ArubaOS-Switch. Defaults to False
+            aos_sw (bool, optional): Device is ArubaOS-Switch. Defaults to False (CX Switch)
 
         Returns:
             Response: CentralAPI Response object

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1110,20 +1110,25 @@ class CentralApi(Session):
     # API-FLAW aos-sw always shows VLAN as 1 (allowed_vlans represents the PVID for an access port, include all VLANs on a trunk port, no indication of native)
     # API-FLAW aos-sw always shows mode as access, cx does as well, but has vlan_mode which is accurate
     # API-FLAW neither show interface name/description
-    async def get_switch_ports(self, serial: str, slot: str = None, aos_sw: bool = False) -> Response:
+    async def get_switch_ports(self, iden: str, slot: str = None, stack: bool = False, aos_sw: bool = False) -> Response:
         """Switch Ports Details.
 
         Args:
-            serial (str): Serial number of switch to be queried
+            iden (str): Serial number of switch to be queried or the stack_id if it's a stack
             slot (str, optional): Slot name of the ports to be queried {For chassis type switches
                 only}.
+            stack: (bool, optional) : Get details for stack vs individual switch (iden needs to be the stack_id)
+                Defaults to False.
             aos_sw (bool, optional): Device is ArubaOS-Switch. Defaults to False (indicating CX switch)
 
         Returns:
             Response: CentralAPI Response object
         """
-        sw_path = "cx_switches" if not aos_sw else "switches"
-        url = f"/monitoring/v1/{sw_path}/{serial}/ports"
+        if stack:
+            sw_path = "cx_switch_stacks" if not aos_sw else "switch_stacks"
+        else:
+            sw_path = "cx_switches" if not aos_sw else "switches"
+        url = f"/monitoring/v1/{sw_path}/{iden}/ports"
 
         params = {"slot": slot}
 

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1400,7 +1400,10 @@ def get_ospf_interface(data: Union[List[dict], dict],) -> Union[List[dict], dict
     return data
 
 def show_interfaces(data: Union[List[dict], dict], verbosity: int = 0, dev_type: DevTypes = "cx") -> Union[List[dict], dict]:
-    data = utils.listify(data)
+    if isinstance(data, list) and data and "member_port_detail" in data[0]:
+        data = [p for sw in data[0]["member_port_detail"] for p in sw["ports"]]
+    else:
+        data = utils.listify(data)
 
     # TODO verbose and non-verbose
     # TODO determine if "mode" has any value, appears to always be Access on SW

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1740,3 +1740,17 @@ def cloudauth_upload_status(data: List[Dict[str, Any]] | Dict[str, Any]) -> Dict
         del data["durationNanos"]
 
     return data
+
+def cloudauth_get_namedmpsk(data: List[Dict[str, Any]], verbosity: int = 0,) -> List[Dict[str, Any]]:
+    verbosity_keys = {
+        0: [
+            'name',
+            'role',
+            'status',
+        ]
+    }
+
+    if verbosity == 0:  # currently no verbosity beyond 0, we just don't filter the fields
+        data = [{k: d.get(k) for k in verbosity_keys.get(verbosity, verbosity_keys[max(verbosity_keys.keys())])} for d in data]
+
+    return data

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1310,7 +1310,7 @@ def get_device_inventory(data: List[dict], sub: bool = None) -> List[dict]:
     # combine type / device_type for verbose output, preferring type from cache
 
     data = [
-        {"type": _inv_type(d["model"], d.get("type", d["device_type"])), **{key: val for key, val in d.items() if key != "device_type"}}
+        {"type": _inv_type(d["model"], d.get("type", d.get("device_type", "err"))), **{key: val for key, val in d.items() if key != "device_type"}}
         for d in data
     ]
     data = [

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -31,7 +31,7 @@ except (ImportError, ModuleNotFoundError) as e:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.constants import DevTypes
+from centralcli.constants import DevTypes, StatusOptions
 from centralcli.objects import DateTime
 
 
@@ -1611,3 +1611,17 @@ def get_wlans(data: List[dict]) ->  List[dict]:
     return simple_kv_formatter(data)
 
 
+def get_switch_stacks(data: List[Dict[str, str]], status: StatusOptions = None, stack_ids: List[str] = None):
+    simple_types = {"ArubaCX": "cx"}
+    data = [{"name": d.get("name"), **d, "switch_type": simple_types.get(d.get("switch_type", ""), d.get("switch_type"))} for d in data]
+    before = len(data)
+    if status:  # Filter up / down
+        data = [d for d in data if d.get("status").lower() == status.value.lower()]
+    if stack_ids:  # Filter Stack IDs
+        data = [d for d in data if d.get("id") in stack_ids]
+
+    if before and not data:
+        data = "\nNo stacks matched provided filters"
+
+    data = strip_no_value(data)
+    return simple_kv_formatter(data)

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -33,6 +33,7 @@ except (ImportError, ModuleNotFoundError) as e:
 
 from centralcli.constants import DevTypes, StatusOptions
 from centralcli.objects import DateTime
+from centralcli.models import CloudAuthUploadResponse
 
 
 def epoch_convert(func):
@@ -1719,3 +1720,23 @@ def get_switch_stacks(data: List[Dict[str, str]], status: StatusOptions = None, 
 
     data = strip_no_value(data)
     return simple_kv_formatter(data)
+
+
+def cloudauth_upload_status(data: List[Dict[str, Any]] | Dict[str, Any]) -> Dict[str, Any]:
+    if not data:
+        return data
+    else:
+        data = utils.unlistify(data)  # _display_results will listify the data as most outputs are lists of dicts
+
+    try:
+        resp_model = CloudAuthUploadResponse(**data)
+        data = resp_model.dict()
+    except Exception as e:
+        log.error("Attempt to normalize cloudauth upload status response through model failed.")
+        log.exception(e)
+
+    if "durationNanos" in data:
+        data["duration_secs"] = round(data["durationNanos"] / 1_000_000_000, 2)
+        del data["durationNanos"]
+
+    return data

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -378,8 +378,10 @@ def reboot(
                                 autocompletion=cli.cache.account_completion),
 ) -> None:
     """Reboot a device
+
+    Use --swarm to reboot the swarm associated with the specified device (The device can be any AP in the swarm)
     """
-    dev: CentralObject = cli.cache.get_dev_identifier(device)
+    dev: CentralObject = cli.cache.get_dev_identifier(device, conductor_only=True)
 
     conf_msg = dev.rich_help_text
     func = cli.central.send_command_to_device
@@ -399,8 +401,8 @@ def reboot(
     console = Console(emoji=False)
     _msg = "Reboot" if not yes else "Rebooting"
     _msg = f"{_msg} {conf_msg}"
-    console.print(_msg)
 
+    console.print(_msg)
     if yes or typer.confirm("Proceed?", abort=True):
         resp = cli.central.request(func, arg, 'reboot')
         cli.display_results(resp, tablefmt="action")

--- a/centralcli/cliadd.py
+++ b/centralcli/cliadd.py
@@ -57,11 +57,11 @@ class AddGroupArgs(str, Enum):
 # FIXME Not all flows work on 2.5.5  I think license may be broken
 @app.command()
 def device(
-    kw1: AddGroupArgs = typer.Argument(..., hidden=False, metavar="serial",),
-    serial: str = typer.Argument(..., metavar="[SERIAL NUM]", hidden=False, autocompletion=cli.cache.smg_kw_completion, show_default=False,),
-    kw2: str = typer.Argument(..., hidden=False, metavar="mac", autocompletion=cli.cache.smg_kw_completion),
-    mac: str = typer.Argument(..., metavar="[MAC ADDRESS]", hidden=False, autocompletion=cli.cache.smg_kw_completion, show_default=False,),
-    kw3: str = typer.Argument(None, metavar="group", hidden=False, autocompletion=cli.cache.smg_kw_completion),
+    kw1: AddGroupArgs = typer.Argument(..., hidden=True, metavar="serial", show_default=False,),
+    serial: str = typer.Argument(..., metavar="<SERIAL NUM>", hidden=False, autocompletion=cli.cache.smg_kw_completion, show_default=False,),
+    kw2: str = typer.Argument(..., hidden=True, metavar="mac", autocompletion=cli.cache.smg_kw_completion, show_default=False,),
+    mac: str = typer.Argument(..., metavar="<MAC ADDRESS>", hidden=False, autocompletion=cli.cache.smg_kw_completion, show_default=False,),
+    kw3: str = typer.Argument(None, metavar="group", hidden=True, autocompletion=cli.cache.smg_kw_completion, show_default=False,),
     group: str = typer.Argument(None, metavar="[GROUP]", help="pre-assign device to group",
                                autocompletion=cli.cache.smg_kw_completion, show_default=False,),
     # kw4: str = typer.Argument(None, metavar="", hidden=True, autocompletion=cli.cache.smg_kw_completion),
@@ -82,6 +82,8 @@ def device(
     ),
 ) -> None:
     """Add a Device to Aruba Central.
+
+    Serial Number and MAC are required, group is opional.
     """
     kwd_vars = [kw1, kw2, kw3]
     vals = [serial, mac, group]
@@ -110,8 +112,7 @@ def device(
 
     # Error if both serial and mac are not provided
     if not kwargs["mac"] or not kwargs["serial"]:
-        print("[bright_red]Error[/]: both serial number and mac address are required.")
-        raise typer.Exit(1)
+        cli.exit("[bright_red]Error[/]: both serial number and mac address are required.")
 
     api_kwd = {"serial": "serial_num", "mac": "mac_address"}
     kwargs = {api_kwd.get(k, k): v for k, v in kwargs.items() if v}

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -1052,8 +1052,6 @@ def update_dev_inv_cache(console: Console, batch_resp: List[Response], cache_dev
 # TODO DELME temporary debug testing
 def batch_delete_devices_dry_run(data: Union[list, dict], *, ui_only: bool = False, cop_inv_only: bool = False, yes: bool = False) -> List[Response]:
     console = Console(emoji=False)
-    from rich import inspect
-
 
     if not data:
         print("[dark_orange]:warning:[/] [bright_red]Error[/] No data resulted from parsing of import file.")

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -349,6 +349,7 @@ class CLICommon:
         sort_by: str = None,
         reverse: bool = False,
         stash: bool = True,
+        output_by_key: str | List[str] = "name",
         set_width_cols: dict = None,
         full_cols: Union[List[str], str] = [],
         fold_cols: Union[List[str], str] = [],
@@ -388,7 +389,7 @@ class CLICommon:
                         # data = sorted(data, key=get_sort(d[sort_by], type_=type_))
                     except TypeError as e:
                         print(
-                            f":x: [dark_orange3]Warning:[reset] Unable to sort by [cyan]{sort_by}.\n   {e.__class__.__name__}: {e} "
+                            f":warning:  Unable to sort by [cyan]{sort_by}.\n   {e.__class__.__name__}: {e} "
                         )
 
             if reverse:
@@ -408,6 +409,7 @@ class CLICommon:
                 "caption": caption,
                 "account": None if config.account in ["central_info", "default", "account"] else config.account,
                 "config": config,
+                "output_by_key": output_by_key,
                 "set_width_cols": set_width_cols,
                 "full_cols": full_cols,
                 "fold_cols": fold_cols,
@@ -450,6 +452,7 @@ class CLICommon:
         sort_by: str = None,
         reverse: bool = False,
         stash: bool = True,
+        output_by_key: str | List[str] = "name",
         exit_on_fail: bool = False,
         set_width_cols: dict = None,
         full_cols: Union[List[str], str] = [],
@@ -478,6 +481,8 @@ class CLICommon:
             reverse (bool, optional): reverse the output.
             stash (bool, optional): stash (cache) the output of the command.  The CLI can re-display with
                 show last.  Default: True
+            output_by_key: For json or yaml output, if any of the provided keys are foound in the List of dicts
+                the List will be converted to a Dict[value of provided key, original_inner_dict].  Defaults to name.
             ok_status (Union[int, List[int], Tuple[int, str], List[Tuple[int, str]]], optional): By default
                 responses with status_code 2xx are considered OK and are rendered as green by
                 Output class.  provide int or list of int to override additional status_codes that
@@ -571,6 +576,7 @@ class CLICommon:
                         sort_by=sort_by,
                         reverse=reverse,
                         stash=stash,
+                        output_by_key=output_by_key,
                         set_width_cols=set_width_cols,
                         full_cols=full_cols,
                         fold_cols=fold_cols,
@@ -596,6 +602,7 @@ class CLICommon:
                 sort_by=sort_by,
                 reverse=reverse,
                 stash=stash,
+                output_by_key=output_by_key,
                 set_width_cols=set_width_cols,
                 full_cols=full_cols,
                 fold_cols=fold_cols,

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -995,21 +995,23 @@ def upgrade(
 @app.command("cache", help="Show contents of Identifier Cache.", hidden=True)
 def cache_(
     args: List[CacheArgs] = typer.Argument(None, show_default=False),
-    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON", show_default=False,),
-    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV", show_default=False),
-    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML", show_default=False,),
-    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
-    sort_by: str = typer.Option(None, "--sort", help="Field to sort by", show_default=False,),
-    reverse: bool = typer.Option(False, "-r", help="Reverse output order", show_default=False,),
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON", show_default=False, rich_help_panel="Formatting"),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML", show_default=False, rich_help_panel="Formatting"),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV", show_default=False, rich_help_panel="Formatting"),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format", show_default=False, rich_help_panel="Formatting"),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False, rich_help_panel="Common Options"),
+    sort_by: str = typer.Option(None, "--sort", help="Field to sort by", show_default=False, rich_help_panel="Common Options"),
+    reverse: bool = typer.Option(False, "-r", help="Reverse output order", show_default=False, rich_help_panel="Common Options"),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True,),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
-    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False, rich_help_panel="Common Options"),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging", rich_help_panel="Common Options"),
     account: str = typer.Option(
         "central_info",
         envvar="ARUBACLI_ACCOUNT",
         help="The Aruba Central Account to use (must be defined in the config)",
         autocompletion=cli.cache.account_completion,
+        rich_help_panel="Common Options",
     ),
 ):
     args = ('all',) if not args else args
@@ -1023,7 +1025,7 @@ def cache_(
         elif arg.value == "devices":
             cache_out = sorted(cache_out, key=lambda i: (i.get("site") or "", i.get("type") or "", i.get("name") or ""))
 
-        tablefmt = cli.get_format(do_json=do_json, do_csv=do_csv, do_yaml=do_yaml, default="rich" if "all" not in args else "yaml")
+        tablefmt = cli.get_format(do_json=do_json, do_csv=do_csv, do_yaml=do_yaml, do_table=do_table, default="rich" if "all" not in args else "yaml")
         cli.display_results(
             data=cache_out,
             tablefmt=tablefmt,

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -166,7 +166,7 @@ def show_devices(
             caption = None if not resp.ok else _build_caption(resp)
         else:  # No filtering params, get update from cache
             if central.get_all_devicesv2 not in cli.cache.updated:
-                resp = central.request(cli.cache.update_dev_db)
+                resp = central.request(cli.cache.update_dev_db, **params)
                 caption = _build_caption(resp)
             else:
                 # get_all_devicesv2 already called (to populate/update cache) grab response from cache.
@@ -204,7 +204,7 @@ def all_(
     pub_ip: str = typer.Option(None, help="Filter by Public IP", show_default=False,),
     up: bool = typer.Option(False, "--up", help="Filter by devices that are Up", show_default=False),
     down: bool = typer.Option(False, "--down", help="Filter by devices that are Down", show_default=False),
-    do_stats: bool = typer.Option(False, "--stats", is_flag=True, help="Show device statistics"),
+    do_stats: bool = typer.Option(False, "--stats", is_flag=True, help="Show device statistics", hidden=True,),  # TODO --stats for APs not showing with show all only with show aps so cpu etc is being filtered when gws switches also included (common keys)
     # do_clients: bool = typer.Option(False, "--clients", is_flag=True, help="Calculate client count (per device)"),
     verbose: bool = typer.Option(
         False,

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2009,6 +2009,31 @@ def cluster(
     cli.display_results(resp, tablefmt=tablefmt, title=f"Cluster details for [green]{ssid}[/] in group [green]{group.name}[/]", pager=pager, outfile=outfile, cleaner=cleaner.simple_kv_formatter)
 
 
+@app.command("mpsk-networks")
+def mpsk_networks(
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format",),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
+) -> None:
+    """Show all MPSK networks
+    """
+    resp = cli.central.request(cli.central.cloudauth_get_mpsk_networks)
+    tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
+    cli.display_results(resp, tablefmt=tablefmt, title="MPSK Networks", pager=pager, outfile=outfile, full_cols=["id", "accessURL"])
+
+
 @app.command()
 def vsx(
     device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_switch_completion, show_default=False,),

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -954,7 +954,7 @@ def vlans(
         autocompletion=cli.cache.dev_gw_switch_site_completion,
         show_default=False,
     ),
-    stack: bool = typer.Option(False, "-s", "--stack", help="Get VLANs for entire stack [grey42]\[default: Get VLANs for the individual member switch specified][/]"),
+    # stack: bool = typer.Option(False, "-s", "--stack", help="Get VLANs for entire stack [grey42]\[default: Get VLANs for the individual member switch specified][/]"),
     status: StatusOptions = typer.Option(None, metavar="[up|down]", hidden=True, help="Filter by VLAN status"),
     state: StatusOptions = typer.Option(None, hidden=True),  # alias for status, both hidden to simplify as they can use --up or --down
     up: bool = typer.Option(False, "--up", help="Filter by devices that are Up", show_default=False),
@@ -984,7 +984,7 @@ def vlans(
     """
     # TODO cli command lacks the filtering options available from method currently.
     central = cli.central
-    obj = cli.cache.get_identifier(dev_site, qry_funcs=("dev", "site"), swack=stack)
+    obj: CentralObject = cli.cache.get_identifier(dev_site, qry_funcs=("dev", "site"), conductor_only=True)
 
     if up:
         status = "Up"
@@ -998,7 +998,13 @@ def vlans(
         resp = central.request(central.get_site_vlans, obj.id)
     elif obj.is_dev:
         if obj.generic_type == "switch":
-            iden = obj.serial if not stack else obj.swack_id
+            if obj.swack_id:
+                iden = obj.swack_id
+                stack = True
+            else:
+                iden = obj.serial
+                stack = False
+
             resp = central.request(central.get_switch_vlans, iden, stack=stack, aos_sw=obj.type == "sw")
         elif obj.type.lower() == 'gw':
             resp = central.request(central.get_gateway_vlans, obj.serial)

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -23,12 +23,12 @@ except (ImportError, ModuleNotFoundError):
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import Response, cleaner, clishowfirmware, clishowwids, clishowbranch, clishowospf, clitshoot, clishowtshoot, clishowoverlay, clishowaudit, clishowcloudauth, BatchRequest, caas, render, cli, utils, config, log
+    from centralcli import Response, cleaner, clishowfirmware, clishowwids, clishowbranch, clishowospf, clitshoot, clishowtshoot, clishowoverlay, clishowaudit, clishowcloudauth, clishowmpsk, BatchRequest, caas, render, cli, utils, config, log
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import Response, cleaner, clishowfirmware, clishowwids, clishowbranch, clishowospf, clitshoot, clishowtshoot, clishowoverlay, clishowaudit, clishowcloudauth, BatchRequest, caas, render, cli, utils, config, log
+        from centralcli import Response, cleaner, clishowfirmware, clishowwids, clishowbranch, clishowospf, clitshoot, clishowtshoot, clishowoverlay, clishowaudit, clishowcloudauth, clishowmpsk, BatchRequest, caas, render, cli, utils, config, log
     else:
         print(pkg_dir.parts)
         raise e
@@ -49,6 +49,7 @@ app.add_typer(clishowtshoot.app, name="tshoot")
 app.add_typer(clishowoverlay.app, name="overlay")
 app.add_typer(clishowaudit.app, name="audit")
 app.add_typer(clishowcloudauth.app, name="cloud-auth")
+app.add_typer(clishowmpsk.app, name="mpsk")
 
 tty = utils.tty
 iden_meta = IdenMetaVars()
@@ -2007,31 +2008,6 @@ def cluster(
     if tablefmt == "rich":
         resp.output = [{"SSID": resp.output.get("profile", ""), **d} for d in resp.output.get("gw_cluster_list", resp.output)]
     cli.display_results(resp, tablefmt=tablefmt, title=f"Cluster details for [green]{ssid}[/] in group [green]{group.name}[/]", pager=pager, outfile=outfile, cleaner=cleaner.simple_kv_formatter)
-
-
-@app.command("mpsk-networks")
-def mpsk_networks(
-    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
-    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
-    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
-    do_table: bool = typer.Option(False, "--table", help="Output in table format",),
-    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
-    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
-    update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
-    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
-    account: str = typer.Option(
-        "central_info",
-        envvar="ARUBACLI_ACCOUNT",
-        help="The Aruba Central Account to use (must be defined in the config)",
-        autocompletion=cli.cache.account_completion,
-    ),
-) -> None:
-    """Show all MPSK networks
-    """
-    resp = cli.central.request(cli.central.cloudauth_get_mpsk_networks)
-    tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
-    cli.display_results(resp, tablefmt=tablefmt, title="MPSK Networks", pager=pager, outfile=outfile, full_cols=["id", "accessURL"])
 
 
 @app.command()

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -820,7 +820,7 @@ def vlans(
         autocompletion=cli.cache.dev_gw_switch_site_completion,
         show_default=False,
     ),
-    # port: List[int] = typer.Argument(None, help="Optional list of interfaces to filter on"),
+    stack: bool = typer.Option(False, "-s", "--stack", help="Get VLANs for entire stack [grey42]\[default: Get VLANs for the individual member switch specified][/]"),
     status: StatusOptions = typer.Option(None, metavar="[up|down]", hidden=True, help="Filter by VLAN status"),
     state: StatusOptions = typer.Option(None, hidden=True),  # alias for status, both hidden to simplify as they can use --up or --down
     up: bool = typer.Option(False, "--up", help="Filter by devices that are Up", show_default=False),
@@ -850,7 +850,7 @@ def vlans(
     """
     # TODO cli command lacks the filtering options available from method currently.
     central = cli.central
-    obj = cli.cache.get_identifier(dev_site, qry_funcs=("dev", "site"))
+    obj = cli.cache.get_identifier(dev_site, qry_funcs=("dev", "site"), swack=stack)
 
     if up:
         status = "Up"
@@ -864,7 +864,8 @@ def vlans(
         resp = central.request(central.get_site_vlans, obj.id)
     elif obj.is_dev:
         if obj.generic_type == "switch":
-            resp = central.request(central.get_switch_vlans, obj.serial, aos_sw=obj.type == "sw")
+            iden = obj.serial if not stack else obj.swack_id
+            resp = central.request(central.get_switch_vlans, iden, stack=stack, aos_sw=obj.type == "sw")
         elif obj.type.lower() == 'gw':
             resp = central.request(central.get_gateway_vlans, obj.serial)
         else:

--- a/centralcli/clishowcloudauth.py
+++ b/centralcli/clishowcloudauth.py
@@ -11,17 +11,17 @@ from rich import print
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import cli
+    from centralcli import cli, cleaner
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import cli
+        from centralcli import cli, cleaner
     else:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.constants import CloudAuthMacSortBy
+from centralcli.constants import CloudAuthMacSortBy, CloudAuthUploadType
 
 app = typer.Typer()
 
@@ -83,6 +83,60 @@ def registered_macs(
         outfile=outfile,
         sort_by=sort_by,
         reverse=reverse
+    )
+
+
+@app.command()
+def upload(
+    what: CloudAuthUploadType = typer.Argument("mac", show_default=True),
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format"),
+    sort_by: str = typer.Option(None, "--sort", show_default=False,),
+    reverse: bool = typer.Option(
+        False, "-r",
+        help="Reverse Output order Default order: newest on bottom.",
+        show_default=False
+    ),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    default: bool = typer.Option(
+        False, "-d",
+        is_flag=True,
+        help="Use default central account",
+        show_default=False,
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        envvar="ARUBACLI_DEBUG",
+        help="Enable Additional Debug Logging",
+    ),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
+) -> None:
+    """Show Cloud-Auth Upload Status.
+
+    This command can be ran after [cyan]cencli batch add <macs|mpsk> to see the status of the upload.
+    """
+    resp = cli.central.request(cli.central.cloudauth_upload_status, upload_type=what.value)
+    tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="yaml")
+
+    cli.display_results(
+        resp,
+        tablefmt=tablefmt,
+        title=f"Cloud-Auth Upload [cyan]{what.upper()}s[/] Status",
+        caption=None,
+        pager=pager,
+        outfile=outfile,
+        sort_by=sort_by,
+        reverse=reverse,
+        cleaner=cleaner.cloudauth_upload_status
     )
 
 @app.callback()

--- a/centralcli/clishowcloudauth.py
+++ b/centralcli/clishowcloudauth.py
@@ -72,11 +72,13 @@ def registered_macs(
         sort_by = sort_full_names.get(sort_by, sort_by)
 
     resp = cli.central.request(cli.central.cloudauth_get_registered_macs, search=search)
+    caption = None if not resp.ok else f"[cyan]{len(resp.output)}[/] Registered MAC Addresses"
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich")
     cli.display_results(
         resp,
         tablefmt=tablefmt,
         title="Cloud-Auth Registered Mac Addresses",
+        caption=caption,
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,

--- a/centralcli/clishowfirmware.py
+++ b/centralcli/clishowfirmware.py
@@ -111,7 +111,7 @@ def _list(
 ):
     """Show available firmware list for a specific device or a type of device
     """
-    dev: CentralObject = device if not device else cli.cache.get_dev_identifier(device)
+    dev: CentralObject = device if not device else cli.cache.get_dev_identifier(device, conductor_only=True,)
     _dev_type = dev_type if dev_type is None else lib_to_api("firmware", dev_type)
 
     # API-FLAW # HACK API at least for AOS10 APs returns Invalid Value for device <serial>, convert to --dev-type

--- a/centralcli/clishowmpsk.py
+++ b/centralcli/clishowmpsk.py
@@ -46,7 +46,7 @@ def networks(
 ) -> None:
     """Show all MPSK networks (SSIDs)
     """
-    resp = cli.central.request(cli.central.cloudauth_get_mpsk_networks)
+    resp = cli.central.request(cli.cache.update_mpsk_db)
     tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
     cli.display_results(resp, tablefmt=tablefmt, title="MPSK Networks", pager=pager, outfile=outfile, full_cols=["id", "accessURL"])
 

--- a/centralcli/clishowmpsk.py
+++ b/centralcli/clishowmpsk.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import typer
+import sys
+from pathlib import Path
+
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from centralcli import cli, utils, cleaner
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from centralcli import cli, utils, cleaner
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+from centralcli.constants import IdenMetaVars, SortNamedMpskOptions
+
+app = typer.Typer()
+
+tty = utils.tty
+iden_meta = IdenMetaVars()
+
+
+@app.command()
+def networks(
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format",),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
+) -> None:
+    """Show all MPSK networks (SSIDs)
+    """
+    resp = cli.central.request(cli.central.cloudauth_get_mpsk_networks)
+    tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
+    cli.display_results(resp, tablefmt=tablefmt, title="MPSK Networks", pager=pager, outfile=outfile, full_cols=["id", "accessURL"])
+
+
+# TODO sort_by options
+@app.command()
+def named(
+    ssid: str = typer.Argument(..., help="The SSID to gather named MPSK definitions for", autocompletion=cli.cache.mpsk_completion, show_default=False,),
+    name: str = typer.Option(None, help="Filter by MPSK name (name contains)", show_default=False, rich_help_panel="Filtering Options",),
+    role: str = typer.Option(None, help="Filter by user role associated with the MPSK (role name contains)", show_default=False, rich_help_panel="Filtering Options",),
+    enabled: bool = typer.Option(None, "-E", "--enabled", help="Show enabled named MPSKs", show_default=False, rich_help_panel="Filtering Options",),
+    disabled: bool = typer.Option(None, "-D", "--disabled", help="Show disabled named MPSKs", show_default=False, rich_help_panel="Filtering Options",),
+    verbose: int = typer.Option(
+        0,
+        "-v",
+        count=True,
+        help="Verbosity: Show more details, Accepts -vv -vvv etc. for increasing verbosity where supported",
+        show_default=False,
+    ),
+    sort_by: SortNamedMpskOptions = typer.Option(None, "--sort", help="Field to sort by [grey42]Only \[name|role|status] valid unless -v specified[/]", rich_help_panel="Formatting", show_default=False,),
+    reverse: bool = typer.Option(False, "-r", is_flag=True, help="Sort in descending order", rich_help_panel="Formatting"),
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON", rich_help_panel="Formatting",),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML", rich_help_panel="Formatting",),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV", rich_help_panel="Formatting",),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format", rich_help_panel="Formatting",),
+    csv_import: bool = typer.Option(False, "--import", help="Output named MPSKs using format required for import into Cloud-Auth [grey42 italic]implies --csv[/]", show_default=False, rich_help_panel="Formatting",),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False, rich_help_panel="Common Options",),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output", rich_help_panel="Common Options",),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False, rich_help_panel="Common Options",),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",rich_help_panel="Common Options",),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+        rich_help_panel="Common Options",
+    ),
+) -> None:
+    """Show named MPSK definitions for a provided network (SSID)
+    """
+    status = None
+    if enabled:
+        status = "enabled"
+    elif disabled:
+        status = "disabled"
+
+    ssid = cli.cache.get_mpsk_identifier(ssid)
+    if not csv_import:
+        resp = cli.central.request(cli.central.cloudauth_get_namedmpsk, ssid.id, name=name, role=role, status=status)
+        _cleaner = cleaner.cloudauth_get_namedmpsk
+    else:
+        resp = cli.central.request(cli.central.cloudauth_download_mpsk_csv, ssid.name, name=name, filename=outfile, role=role, status=status)
+        _cleaner = None
+
+    tablefmt = "csv" if csv_import else cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
+    caption = None if not resp.ok else f"{'' if tablefmt == 'rich' else '  '}Total Named MPSKs for [cyan]{ssid.name}[/]: [bright_green]{len(resp)}[/]"
+    cli.display_results(resp, tablefmt=tablefmt, title="MPSK Networks", caption=caption, sort_by=sort_by, reverse=reverse, pager=pager, outfile=outfile, cleaner=_cleaner, verbosity=verbose)
+
+
+@app.callback()
+def callback():
+    """
+    Show MPSK details
+    """
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/centralcli/clitshoot.py
+++ b/centralcli/clitshoot.py
@@ -114,7 +114,7 @@ def ts_send_command(device: CentralObject, cmd: str, outfile: Path, pager: bool,
 
 @app.command()
 def overlay(
-    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, show_default=False,),
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_ap_gw_sw_completion, show_default=False,),
     outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
@@ -163,7 +163,7 @@ def overlay(
 
 @app.command()
 def clients(
-    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, show_default=False,),
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_ap_gw_sw_completion, show_default=False,),
     wired: bool = typer.Option(False, "-w", "--wired", help="Include [cyan]show clients wired[/] (applies to AP)",),
     outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
@@ -306,7 +306,7 @@ def show_tech(
 
 @app.command()
 def images(
-    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, show_default=False,),
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_ap_gw_sw_completion, show_default=False,),
     outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),

--- a/centralcli/clitshoot.py
+++ b/centralcli/clitshoot.py
@@ -124,7 +124,7 @@ def overlay(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ):
-    """Show GW or AP Overlay details (Tunneled SSIDs) or AOS-SW User Based Tunneling
+    """Show GW or AP Overlay details (Tunneled SSIDs) or AOS-SW User Based Tunneling  (valid on AP, GW, and AOS-SW)
 
     [cyan]Returns the output of the following commands useful in troubleshooting overlay AP / gateway / ubt tunnels.[/]
 
@@ -156,10 +156,7 @@ def overlay(
         "gw": [2452, 2515, 2453, 2131, 2441, 2454, 2455],
         "sw": [1189, 1195, 1196, 1191]
     }
-    dev = cli.cache.get_dev_identifier(device)
-    if dev.type == "cx":
-        print(":warning:  Command not supported on CX switches.")
-        raise typer.Exit(1)
+    dev = cli.cache.get_dev_identifier(device, dev_type=["ap", "gw", "sw"])
 
     commands = ids_by_dev_type[dev.type]
     send_cmds_by_id(dev, commands=commands, pager=pager, outfile=outfile)
@@ -177,9 +174,9 @@ def clients(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ):
-    """Show output of client related commands
+    """Show output of client related commands  (valid on AP, GW, and AOS-SW)
 
-    [cyan]Returns the output of the following client related commands.[/]
+    [cyan]Returns the output of the following client related commands. Valid for AP, GW, and AOS-SW.[/]
 
     [bright_green]APs[/]
     [cyan]-[/] show clients
@@ -203,10 +200,7 @@ def clients(
         "sw": [1028, 1089],
         "gw": [2163, 2095],
     }
-    dev: CentralObject = cli.cache.get_dev_identifier(device)
-    if dev.type == "cx":
-        print(":warning:  Command not supported on CX switches.")
-        raise typer.Exit(1)
+    dev: CentralObject = cli.cache.get_dev_identifier(device, dev_type=["ap", "gw", "sw"])
 
     commands = ids_by_dev_type[dev.type]
     if wired:
@@ -230,7 +224,7 @@ def dpi(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ):
-    """Show DPI output (valid on APs or GWs)
+    """Show DPI output (valid on APs and GWs)
 
     [cyan]Returns the output of the following DPI related commands.[/]
 
@@ -322,7 +316,7 @@ def images(
                                 help="The Aruba Central Account to use (must be defined in the config)",
                                 autocompletion=cli.cache.account_completion),
 ):
-    """Show image versions
+    """Show image versions (Valid for AP, GW, and AOS-SW)
 
     [cyan]Returns the output of the following image related commands.[/]
 
@@ -337,10 +331,7 @@ def images(
     [bright_green]AOS-SW[/]
     [cyan]-[/] show flash
     """
-    dev: CentralObject = cli.cache.get_dev_identifier(device)
-    if dev.type == "cx":
-        print(":warning:  Command not supported on CX switches.")
-        raise typer.Exit(1)
+    dev: CentralObject = cli.cache.get_dev_identifier(device, dev_type=["ap", "gw", "sw"])
 
     ids_by_dev_type = {
         "ap": [119, 213],

--- a/centralcli/cliupgrade.py
+++ b/centralcli/cliupgrade.py
@@ -30,7 +30,7 @@ app = typer.Typer()
 
 # You can only specify one of group, swarm_id or serial parameters
 
-@app.command(short_help="Upgrade firmware on a specific device",)
+@app.command()
 def device(
     device: str = typer.Argument(
         ...,
@@ -62,6 +62,8 @@ def device(
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",),
 ) -> None:
+    """Upgrade firmware on a device
+    """
     dev = cli.cache.get_dev_identifier(device, swack=True)
     if dev.generic_type == "ap":
         reboot = True

--- a/centralcli/cliupgrade.py
+++ b/centralcli/cliupgrade.py
@@ -62,7 +62,7 @@ def device(
                                 envvar="ARUBACLI_ACCOUNT",
                                 help="The Aruba Central Account to use (must be defined in the config)",),
 ) -> None:
-    dev = cli.cache.get_dev_identifier(device)
+    dev = cli.cache.get_dev_identifier(device, swack=True)
     if dev.generic_type == "ap":
         reboot = True
     at = None if not at else int(round(at.timestamp()))
@@ -75,7 +75,7 @@ def device(
     if yes or typer.confirm("\nProceed?", abort=True):
         if dev.type == "ap":  # TODO need to validate this is the same behavior for 8.x IAP.
             # For AOS10 AP need to specifiy serial number as the swarm_id in payload to upgrade individual AP
-            resp = cli.central.request(cli.central.upgrade_firmware, scheduled_at=at, swarm_id=dev.serial, firmware_version=version, reboot=reboot)
+            resp = cli.central.request(cli.central.upgrade_firmware, scheduled_at=at, swarm_id=dev.swack_id, firmware_version=version, reboot=reboot)
         else:
             resp = cli.central.request(cli.central.upgrade_firmware, scheduled_at=at, serial=dev.serial, firmware_version=version, reboot=reboot)
         cli.display_results(resp, tablefmt="action")

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -145,24 +145,6 @@ def _get_config_file(dirs: List[Path]) -> Path:
             if f.suffix in valid_ext and 'base_url' in f.read_text():
                 return f
 
-def _get_user_input(valid: list) -> str:
-    choice = ""
-    try:
-        while choice.lower() not in valid:
-            choice = input(" >> ")
-            if choice.lower() == "abort":
-                print("Aborted")
-                sys.exit()
-            elif choice.lower() not in valid:
-                print(
-                    f"[red]Invalid input.[/red] {choice}.\n"
-                    f"  Select from: {', '.join(valid)}"
-                )
-        return choice
-    except (KeyboardInterrupt, EOFError):
-        print("Aborted")
-        sys.exit()
-
 
 class SafeLineLoader(yaml.SafeLoader):
     """Loader class that keeps track of line numbers."""

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -281,6 +281,7 @@ class CacheArgs(str, Enum):
     hook_config = "hook_config"
     hook_data = "hook_data"
     hook_active = "hook_active"
+    mpsk = "mpsk"
 
 
 class KickArgs(str, Enum):
@@ -684,6 +685,13 @@ class SortWlanOptions(str, Enum):
     access_type = "access_type"
     group = "group"
 
+
+class SortNamedMpskOptions(str, Enum):
+    _id = "id"
+    name = "name"
+    role = "role"
+    status = "status"
+    mpsk = "mpsk"
 
 class SortDevOptions(str, Enum):
     name = "name"

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -777,6 +777,16 @@ class SortSiteOptions(str, Enum):
     associated_devices = "associated_devices"
 
 
+class SortGroupOptions(str, Enum):
+    name = "name"
+    AOSVersion = "AOSVersion"
+    AllowedDevTypes = "AllowedDevTypes"
+    ApNetworkRole = "ApNetworkRole"
+    Architecture = "Architecture"
+    GwNetworkRole = "GwNetworkRole"
+    template_group = "template_group"
+
+
 class SortVlanOptions(str, Enum):
     name = "name"
     pvid = "pvid"

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -298,7 +298,13 @@ class BatchAddArgs(str, Enum):
     groups = "groups"
     devices = "devices"
     labels = "labels"
+    macs = "macs"
+    mpsk = "mpsk"
 
+# CloudAuthUploadType = Literal["mpsk", "mac"]
+class CloudAuthUploadType(str, Enum):
+    mpsk = "mpsk"
+    mac = "mac"
 
 class BatchDelArgs(str, Enum):
     sites = "sites"

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -48,6 +48,12 @@ class SendConfigDevIdens(str, Enum):
     # cx = "cx"
 
 
+class PoEDetectionStatus(Enum):
+    NA = 0
+    Undefined = 1
+    Searching = 2
+    Delivering = 3
+
 class ShowInventoryArgs(str, Enum):
     all = "all"
     ap = "ap"

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -50,9 +50,19 @@ class SendConfigDevIdens(str, Enum):
 
 class PoEDetectionStatus(Enum):
     NA = 0
-    Undefined = 1
+    Undefined = 1  # TODO figure out what this status is
     Searching = 2
     Delivering = 3
+
+
+# Not used currently # TODO reference in cleaner
+class SwitchRoles(Enum):
+    ERR = 0
+    StandAlone = 1
+    StackConductor = 2
+    StackSecondary = 3
+    StackMember = 4
+
 
 class ShowInventoryArgs(str, Enum):
     all = "all"

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -58,6 +58,16 @@ class ShowInventoryArgs(str, Enum):
     switch = "switch"
 
 
+class SortStackOptions(str, Enum):
+    group = "group"
+    _id = "id"
+    mac = "mac"
+    name = "name"
+    split_policy = "split_policy"
+    status = "status"
+    topology = "topology"
+
+
 class SortWebHookOptions(str, Enum):
     name = "name"
     updated = "updated"
@@ -144,6 +154,7 @@ STRIP_KEYS = [
     "areas",
     "lsas",
     "commands",
+    "stacks",
 ]
 
 

--- a/centralcli/logger.py
+++ b/centralcli/logger.py
@@ -25,6 +25,7 @@ log_colors = {
 #     "warning": "[dark_orange4]",
 # }
 console = Console(emoji=False, markup=False)
+emoji_console = Console(markup=False)
 to_debug = [
     "Loaded token from storage from file"
 ]
@@ -119,7 +120,7 @@ class MyLogger:
             self.log_msgs += _msgs
             for m in self.log_msgs:
                 if console.is_terminal or environ.get("PYTEST_CURRENT_TEST"):
-                    typer.secho(m, fg=log_colors.get(level))
+                    emoji_console.print(f"{':warning:  ' if not level=='info' else ''}{m}")
             self.log_msgs = []
 
         if caption:

--- a/centralcli/models.py
+++ b/centralcli/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 
 import pendulum
 from pydantic import BaseModel, Field, validator, IPvAnyAddress
@@ -570,3 +570,25 @@ class Item(BaseModel):
 class UserAccounts(BaseModel):
     items: List[Item]
     total: int
+
+class CloudAuthUploadStats(BaseModel):
+    completed: int
+    failed: int
+    total: int
+
+
+class CloudAuthUploadResponse(BaseModel):
+    details: Dict[str, Any]
+    status: str
+    stats: CloudAuthUploadStats
+    submittedAt: datetime
+    lastUpdatedAt: datetime
+    durationNanos: int
+    fileName: str
+
+    _normalize_datetimes = validator("lastUpdatedAt", "submittedAt", allow_reuse=True)(lambda v: " ".join(pendulum.from_timestamp(v.timestamp(), tz="local").to_day_datetime_string().split()[1:]))
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: pendulum.from_timestamp(v).to_day_datetime_string(),
+        }

--- a/centralcli/models.py
+++ b/centralcli/models.py
@@ -592,3 +592,22 @@ class CloudAuthUploadResponse(BaseModel):
         json_encoders = {
             datetime: lambda v: pendulum.from_timestamp(v).to_day_datetime_string(),
         }
+
+class MpskNetwork(BaseModel):
+    id: str
+    ssid: str
+    accessURL: str
+    passwordPolicy: str
+
+
+class MpskNetworks(BaseModel):
+    items: List[MpskNetwork]
+
+
+class CacheMpskNetwork(BaseModel):
+    id: str
+    name: str = Field(alias="ssid")
+
+
+class CacheMpskNetworks(BaseModel):
+    items: List[CacheMpskNetwork]

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -401,13 +401,12 @@ def output(
                     raw_data = typer.unstyle("{}\n".format('\n'.join(outdata).rstrip('\n')))
                     table_data = "{}\n".format('\n'.join(outdata).rstrip('\n'))
                 else:
-                    raw_data = table_data = "{}\n".format('\n'.join(outdata).rstrip('\n'))
+                    raw_data = "{}\n".format('\n'.join(outdata).rstrip('\n'))
                     table_data = rich_capture(raw_data)
 
-        else:
-            raw_data = table_data = '\n'.join(outdata)
-            # Not sure what hit's this, but it was created so something must
-            log.debug("List[str] else hit")
+        else:  # cencli show config <GW> is list of strings
+            raw_data = '\n'.join(outdata)
+            table_data = rich_capture(raw_data)
 
     if _lexer and raw_data:
         table_data = highlight(bytes(raw_data, 'UTF-8'),

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -429,6 +429,8 @@ def rich_capture(text: str | List[str], emoji: bool = False, **kwargs) -> str:
     Args:
         text (str | List[str]): The text or list of text to capture.
             If provided as list it will be converted to string (joined with \n)
+        emoji: (bool, Optional): Allow emoji placeholders.  Default: False
+        kwargs: additional kwargs passed to rich Console.
 
     Returns:
         str: text with markups converted to ascii control chars

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -322,11 +322,12 @@ def output(
     caption: str = None,
     account: str = None,
     config: Config = None,
+    output_by_key: str | List[str] = "name",
     set_width_cols: dict = None,
     full_cols: Union[List[str], str] = [],
     fold_cols: Union[List[str], str] = [],
 ) -> Output:
-    # log.debugv(f"data passed to output():\n{pprint(outdata, indent=4)}")
+    output_by_key = output_by_key if isinstance(output_by_key, list) else [output_by_key]
     raw_data = outdata
     _lexer = table_data = None
 
@@ -337,14 +338,17 @@ def output(
     if outdata and all(isinstance(x, str) for x in outdata):
         tablefmt = "strings"
 
-    # -- convert List[dict] --> Dict[dev_name: dict] for yaml/json outputs
+    # -- convert List[dict] --> Dict[dev_name: dict] for yaml/json outputs unless output_dict_by_key is specified, then use the provided key(s) rather than name
     if tablefmt in ['json', 'yaml', 'yml']:
         outdata = utils.listify(outdata)
-        if outdata and isinstance(outdata[0], dict) and 'name' in outdata[0]:
-            outdata: Dict[dict] = {
-                item['name']: {k: v for k, v in item.items() if k != 'name'}
-                for item in outdata
-            }
+        if outdata and isinstance(outdata[0], dict):
+            _output_key = [k for k in output_by_key if k in outdata[0]]
+            if _output_key:
+                _output_key = _output_key[0]
+                outdata: Dict[dict] = {
+                    item[_output_key]: {k: v for k, v in item.items() if k != _output_key}
+                    for item in outdata
+                }
 
     if tablefmt == "json":
         outdata = utils.unlistify(outdata)

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Union
 
-import tabulate
+from tabulate import tabulate
 import typer
 import yaml
 import json
@@ -24,12 +24,12 @@ from rich.text import Text
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import log, utils
+    from centralcli import utils
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import log, utils
+        from centralcli import utils
     else:
         print(pkg_dir.parts)
         raise e
@@ -204,7 +204,7 @@ def tabulate_output(outdata: List[dict]) -> tuple:
 
         outdata = _do_subtables(outdata, tablefmt="tabulate")
 
-        table_data = tabulate.tabulate(outdata, headers="keys", tablefmt="tabulate")
+        table_data = tabulate(outdata, headers="keys", tablefmt="tabulate")
         td = table_data.splitlines(keepends=True)
         if td:
             table_data = f"{typer.style(td[0], fg='cyan')}{''.join(td[1:])}"
@@ -327,7 +327,7 @@ def output(
     full_cols: Union[List[str], str] = [],
     fold_cols: Union[List[str], str] = [],
 ) -> Output:
-    output_by_key = output_by_key if isinstance(output_by_key, list) else [output_by_key]
+    output_by_key = utils.listify(output_by_key)
     raw_data = outdata
     _lexer = table_data = None
 
@@ -341,7 +341,7 @@ def output(
     # -- convert List[dict] --> Dict[dev_name: dict] for yaml/json outputs unless output_dict_by_key is specified, then use the provided key(s) rather than name
     if tablefmt in ['json', 'yaml', 'yml']:
         outdata = utils.listify(outdata)
-        if outdata and isinstance(outdata[0], dict):
+        if output_by_key and outdata and isinstance(outdata[0], dict):
             if len(output_by_key) == 1 and "+" in output_by_key[0]:
                 found_keys = [k for k in output_by_key[0].split("+") if k in outdata[0]]
                 if len(found_keys) == len(output_by_key[0].split("+")):

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -342,13 +342,20 @@ def output(
     if tablefmt in ['json', 'yaml', 'yml']:
         outdata = utils.listify(outdata)
         if outdata and isinstance(outdata[0], dict):
-            _output_key = [k for k in output_by_key if k in outdata[0]]
-            if _output_key:
-                _output_key = _output_key[0]
-                outdata: Dict[dict] = {
-                    item[_output_key]: {k: v for k, v in item.items() if k != _output_key}
-                    for item in outdata
-                }
+            if len(output_by_key) == 1 and "+" in output_by_key[0]:
+                found_keys = [k for k in output_by_key[0].split("+") if k in outdata[0]]
+                if len(found_keys) == len(output_by_key[0].split("+")):
+                    outdata: Dict[dict] = {
+                        f"{'-'.join([item[key] for key in found_keys])}": {k: v for k, v in item.items()} for item in outdata
+                    }
+            else:
+                _output_key = [k for k in output_by_key if k in outdata[0]]
+                if _output_key:
+                    _output_key = _output_key[0]
+                    outdata: Dict[dict] = {
+                        item[_output_key]: {k: v for k, v in item.items() if k != _output_key}
+                        for item in outdata
+                    }
 
     if tablefmt == "json":
         outdata = utils.unlistify(outdata)

--- a/centralcli/strings.py
+++ b/centralcli/strings.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from rich.console import Console
 from rich.json import JSON
 from centralcli import log
-import tablib, yaml
+import tablib
+import yaml
 console = Console(emoji=False)
 
 # TODO typer now supports markup_mode="rich" Don't need the help below, can just put the markup in the docstr
@@ -250,7 +251,7 @@ name\nphl-access\nsan-dc-tor\ncom-branches
 {common_add_delete_end}
 """
 
-clibatch_delete_devices_help = f"""
+clibatch_delete_devices_help = """
 [bright_green]Perform batch Delete operations using import data from file.[/]
 
 [cyan]cencli delete sites <IMPORT_FILE>[/] and
@@ -282,7 +283,7 @@ Use '[dark_olive_green2]cencli batch add sites <IMPORT_FILE>[/]' to add multiple
 {_site_common}
 """
 
-clibatch_deploy = f"""
+clibatch_deploy = """
 [bright_green]Batch Deploy[/]
 
 This is a placeholder
@@ -308,7 +309,7 @@ NOTE: Most batch operations are designed so the same file can be used for multip
       the fields not required for a particular automation will be ignored.
 """
 
-clibatch_unsubscribe = f"""
+clibatch_unsubscribe = """
 [italic cyan]cencli batch unsubscribe IMPORT_FILE[/]:
 Accepts the following keys (include as header row for csv import):
     If importing yaml or json the following fields can optionally be under a 'devices' key
@@ -330,6 +331,41 @@ NOTE: Most batch operations are designed so the same file can be used for multip
       the fields not required for a particular automation will be ignored.
 """
 
+data="""Mac Address,Client Name
+00:09:B0:75:65:D1,Integra
+00:1B:4F:23:8A:3E,Avaya VoIP
+3C:A8:2A:A6:07:0B,HP Thin Client"""
+
+clibatch_add_macs = f"""
+[italic cyan]cencli batch add macs IMPORT_FILE[/]:
+
+Requires the following keys (include as header row for csv import):
+[cyan]Mac Address[/]
+Optional keys:
+[cyan]Client Name[/]
+
+{Example(data)}
+"""
+
+data="""Name,MPSK,Client Role,Status
+wade@example.com,chant chemo domain lugged,admin_users,enabled
+jerry@example.com,quick dumpster offset jack,dia,enabled
+stephanie@example.com,random here words go,general_users,enabled"""
+
+clibatch_add_mpsk = f"""
+[italic cyan]cencli batch add mpsk IMPORT_FILE --ssid <SSID>[/]:
+
+Requires the following keys (include as header row for csv import):
+[cyan]Name[/],[cyan]Client Role[/],[cyan]Status[/]
+
+:information:  MPSK will be randomly generated.
+:information:  Roles must exist in Central.
+:information:  [cyan]--ssid[/] Option is required when uploading Named MPSKs.
+
+
+{Example(data)}
+"""
+
 def do_capture(text: str) -> str:
     con = Console()
     con.begin_capture()
@@ -344,6 +380,8 @@ class ImportExamples:
         self.add_sites = clibatch_add_sites
         self.add_groups = clibatch_add_groups
         self.add_labels = clibatch_add_labels
+        self.add_macs = clibatch_add_macs
+        self.add_mpsk = clibatch_add_mpsk
         self.delete_devices = clibatch_delete_devices
         self.delete_sites = clibatch_delete_sites
         self.delete_groups = clibatch_delete_groups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "4.2.0"
+version = "5.0.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -2,15 +2,12 @@
 from typer.testing import CliRunner
 
 from cli import app  # type: ignore # NoQA
-# import json
+from . import update_log
+from centralcli import cache
 
-# from . import TEST_DEVICES
+update_log(f'{__file__.split("/")[-1]}: {id(cache)}')
 
 runner = CliRunner()
-
-# test_dev_file = Path(__file__).parent / 'test_devices.json'
-# if test_dev_file.is_file():
-#     TEST_DEVICES = json.loads(test_dev_file.read_text())
 
 
 def test_add_group1():

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,28 +1,15 @@
-from pathlib import Path
 from typer.testing import CliRunner
 
 from cli import app  # type: ignore # NoQA
-import json
+from . import test_site_file, test_data
 
 runner = CliRunner()
-
-test_file = Path(__file__).parent / 'test_devices.json'
-if test_file.is_file():
-    TEST_DATA = json.loads(test_file.read_text())
-
-test_site_file = test_file.parent.parent / "config" / ".cache" / "test_runner_sites.json"
-
-
-test_site_file.write_text(
-    json.dumps(TEST_DATA["batch"]["sites"])
-)
-
 
 def test_batch_add_sites():
     result = runner.invoke(app, ["batch", "add",  "sites", str(test_site_file), "-Y"])
     assert result.exit_code == 0
-    assert "city" in result.stdout
-    assert "state" in result.stdout
+    assert "city" in result.stdout or "_DUPLICATE_SITE_NAME" in result.stdout
+    assert "state" in result.stdout or "_DUPLICATE_SITE_NAME" in result.stdout
 
 
 def test_batch_del_sites():
@@ -31,4 +18,4 @@ def test_batch_del_sites():
         test_site_file.unlink()
     assert result.exit_code == 0
     assert "success" in result.stdout
-    assert result.stdout.count("success") == len(TEST_DATA["batch"]["sites"])
+    assert result.stdout.count("success") == len(test_data["batch"]["sites"])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -4,9 +4,11 @@ from typing import List, Union
 from cli import app  # type: ignore # NoQA
 from typer.testing import CliRunner
 from centralcli import cache
+from click import Context, Command
 
 runner = CliRunner()
-
+ctx = Context(Command("cencli reset"), info_name="reset", resilient_parsing=True)
+ctx.params={'what': 'overlay', 'device': None, 'yes': None, 'debug': None, 'default': None, 'account': None}
 # TODO make this work
 # work in progress based on https://stackoverflow.com/questions/9137245/unit-test-for-bash-completion-script
 # need to see of typer command runner has a function to test completion
@@ -88,7 +90,7 @@ def test_dev_completion_case_insensitive(incomplete: str = "BSmT"):
     assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])
 
 def test_dev_ap_gw_completion(incomplete: str = "ant"):
-    result = [c for c in cache.dev_ap_gw_completion(incomplete, ["show", "overlay", "summary"])]
+    result = [c for c in cache.dev_ap_gw_completion(ctx=ctx, incomplete=incomplete, args=["show", "overlay", "summary"])]
     assert len(result) > 0
     assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,14 +1,16 @@
-import subprocess
-from typing import List, Union
-
 from cli import app  # type: ignore # NoQA
 from typer.testing import CliRunner
 from centralcli import cache
 from click import Context, Command
+from pathlib import Path
+import json
 
 runner = CliRunner()
 ctx = Context(Command("cencli reset"), info_name="reset", resilient_parsing=True)
 ctx.params={'what': 'overlay', 'device': None, 'yes': None, 'debug': None, 'default': None, 'account': None}
+test_dev_file = Path(__file__).parent / 'test_devices.json'
+if test_dev_file.is_file():
+    TEST_DEVICES = json.loads(test_dev_file.read_text())
 # TODO make this work
 # work in progress based on https://stackoverflow.com/questions/9137245/unit-test-for-bash-completion-script
 # need to see of typer command runner has a function to test completion
@@ -117,5 +119,10 @@ def test_dev_gw_switch_site_completion(incomplete: str = "barn"):
 
 def test_dev_ap_completion_partial_serial(incomplete: str = "CNDDK"):
     result = [c for c in cache.dev_ap_completion(incomplete, ("show", "aps",))]
+    assert len(result) > 0
+    assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])
+
+def test_mpsk_completion_partial_name(incomplete: str = "".join(TEST_DEVICES["mpsk_ssid"].capitalize()[0:-3])):
+    result = [c for c in cache.mpsk_completion(incomplete)]
     assert len(result) > 0
     assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -2,85 +2,15 @@ from cli import app  # type: ignore # NoQA
 from typer.testing import CliRunner
 from centralcli import cache
 from click import Context, Command
-from pathlib import Path
-import json
+from . import test_data
+
 
 runner = CliRunner()
 ctx = Context(Command("cencli reset"), info_name="reset", resilient_parsing=True)
 ctx.params={'what': 'overlay', 'device': None, 'yes': None, 'debug': None, 'default': None, 'account': None}
-test_dev_file = Path(__file__).parent / 'test_devices.json'
-if test_dev_file.is_file():
-    TEST_DEVICES = json.loads(test_dev_file.read_text())
-# TODO make this work
-# work in progress based on https://stackoverflow.com/questions/9137245/unit-test-for-bash-completion-script
-# need to see of typer command runner has a function to test completion
-
-# NEVER GOT THIS TO WORK TEST COMPLETION DIRECT TO THE CACHE COMPLETION FUNCS
-# completion_function = r"""
-# _cencli_completion() {
-#     local IFS=$'
-# '
-#     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \
-#                    COMP_CWORD=$COMP_CWORD \
-#                    _CENCLI_COMPLETE=complete_bash $1 ) )
-#     return 0
-# }
-
-# complete -o default -F _cencli_completion cencli
-
-# """
 
 
-# def test_caas_send_cmds_completion(cmd_base: Union[str, List[str]] = ["cencli", "caas", "send-cmds", "group"], incomplete: str = "Bra"):
-#     # result = runner.invoke(app, [
-#     #     "caas",
-#     #     "send-cmds",
-#     #     "group",
-#     #     "Br",
-#     #     "-Y"
-#     #     ])
-#     # assert result.exit_code == 0
-#     # assert "Success" in result.stdout
-#     cmd_base = cmd_base if isinstance(cmd_base, list) else cmd_base.split()
-#     completion_file="~/.bash_completions/cencli.sh"
-#     cmd = cmd_base + [incomplete]
-#     cmdline = ' '.join(cmd)
-#     print(f"Sending command: {cmdline}")
-#     # full_cmdline=r'source {comp_file};COMP_LINE="{cmdline}"; COMP_WORDS=({cmdline}) COMP_CWORD={cword} COMP_POINT={cmdlen}; $(complete -p {program} | sed "s/.*-F \\([^ ]*\\) .*/\\1/") && echo ${{COMPREPLY[*]}}'.format(
-#     full_cmdline=r'source {comp_file};COMP_LINE="{cmdline}"; COMP_WORDS=({cmdline}); COMP_CWORD={cword}; COMP_POINT={cmdlen}; $(complete -p {program}) && echo ${{COMPREPLY[*]}}'.format(
-#         comp_file=completion_file,
-#         completion_function=completion_function,
-#         cmdline=cmdline,
-#         cmdlen=len(cmdline),
-#         program=cmd[0],
-#         cword=cmd.index(incomplete)
-#     )
-#     print(f"Instructions being sent to shell:\n{full_cmdline}")
-
-#     out = subprocess.Popen(['bash', '-i', '-c', full_cmdline], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-#     stdout, stderr = out.communicate()
-#     _ = [print(line) for line in [*stdout.decode("utf-8").split(), *stderr.decode("utf-8").split()]]
-#     pass
-#     # self.assertEqual(stdout, "Branch1\n")
-
-# test_caas_send_cmds_completion()
-
-        # r'{completion_function} COMP_LINE="{cmdline}" COMP_WORDS=({cmdline}) COMP_CWORD={cword} COMP_POINT={cmdlen} $(complete -p {cmd} | sed "s/.*-F \\([^ ]*\\) .*/\\1/") && echo ${{COMPREPLY[*]}}'.format(
-        #     completion_function=completion_function, cmdline=cmdline, cmdlen=len(cmdline), cmd=cmd[0], cword=cmd.index(incomplete)
-        #     )
-
-        # r'source {completion_file}; COMP_LINE="{cmdline}" COMP_WORDS=({cmdline}) COMP_CWORD={cword} COMP_POINT={cmdlen} $(complete -p {cmd} | sed "s/.*-F \\([^ ]*\\) .*/\\1/") && echo ${{COMPREPLY[*]}}'.format(
-            # completion_file=completion_file, cmdline=cmdline, cmdlen=len(cmdline), cmd=cmd[0], cword=cmd.index(partial_word)
-
-    # full_cmdline=r'{completion_function}COMP_LINE="{cmdline}"; COMP_WORDS=({cmdline}) COMP_CWORD={cword} COMP_POINT={cmdlen}; $(complete -p {program} | sed "s/.*-F \\([^ ]*\\) .*/\\1/") && echo ${{COMPREPLY[*]}}'.format(
-
-# full commands variables replaced with values for direct testing in bash to see if we can get this working
-# source ~/.bash_completions/cencli.sh;COMP_LINE="cencli caas send-cmds group Bra"; COMP_WORDS=(cencli caas send-cmds group Bra); COMP_CWORD=4; COMP_POINT=31; $(complete -p cencli) && echo ${COMPREPLY[*]}
-
-# this relies on one of my aliases showvars
-# source ~/.bash_completions/cencli.sh;export COMP_LINE="cencli caas send-cmds group Bra";export COMP_WORDS=(cencli caas send-cmds group Bra);export COMP_CWORD=4;export COMP_POINT=31;$(complete -p cencli) ; showvars | grep COMP
-
-# TODO dynamically get available devices
+# TODO most are hard-coded need to grab from test_data or dynamically from cache
 def test_dev_completion(incomplete: str = "bsmt"):
     result = [c for c in cache.dev_completion(incomplete)]
     assert len(result) > 0
@@ -122,7 +52,7 @@ def test_dev_ap_completion_partial_serial(incomplete: str = "CNDDK"):
     assert len(result) > 0
     assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])
 
-def test_mpsk_completion_partial_name(incomplete: str = "".join(TEST_DEVICES["mpsk_ssid"].capitalize()[0:-3])):
-    result = [c for c in cache.mpsk_completion(incomplete)]
+def test_mpsk_completion_partial_name(ctx=ctx, incomplete: str = "".join(test_data["mpsk_ssid"].capitalize()[0:-3])):
+    result = [c for c in cache.mpsk_completion(ctx, incomplete)]
     assert len(result) > 0
     assert all([m.lower().startswith(incomplete.lower()) for m in [c if isinstance(c, str) else c[0] for c in result]])

--- a/tests/test_del.py
+++ b/tests/test_del.py
@@ -1,14 +1,10 @@
 from typer.testing import CliRunner
-
 from cli import app  # type: ignore # NoQA
 
 runner = CliRunner()
 
-# test_dev_file = Path(__file__).parent / 'test_devices.json'
-# if test_dev_file.is_file():
-#     TEST_DEVICES = json.loads(test_dev_file.read_text())
 
-
+# Groups are created in test_add
 def test_del_group():
     result = runner.invoke(app, [
         "delete",

--- a/tests/test_devices.json.example
+++ b/tests/test_devices.json.example
@@ -1,51 +1,109 @@
 {
+    "customer_id": "112a10343536f93",
     "switch": {
-        "type": "switch",
-        "group": "WadeLab",
-        "ip": "10.0.30.5",
-        "labels": "",
-        "mac": "f4:03:43:07:57:20",
-        "model": "Aruba2930F-8G-PoE+-2SFP+ Switch(JL258A)",
-        "name": "bsmt-2930F",
-        "public ip": "68.52.67.145",
-        "serial": "CN71HKZ1CL",
-        "site": "WadeLab",
-        "version": "16.10.0011",
         "status": "Up",
-        "test_port": "2"
-        },
+        "name": "av-6100",
+        "model": "6100 12G CL4 2SFP+ 139W Swch (JL679A)",
+        "ip": "10.0.30.4",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "serial": "US0KLRP05S",
+        "group": "WadeLab",
+        "site": "WadeLab",
+        "uptime": "3w 1d 18h 15m 16s",
+        "cpu %": "33%",
+        "mem total": "30",
+        "version": "PL.10.12.0006",
+        "public ip": "1.1.1.1",
+        "type": "ArubaCX",
+        "test_port": "1/1/13",                  # This port will be bounced (both PoE and the interface) during testing
+        "comment": "Test Port is Envisalink"
+    },
+    "template_switch": {
+        "name": "ant-2930F",
+        "ip": "10.2.30.5",
+        "mac": "55:88:22:cc:bb:33",
+        "serial": "CN90HKZP2",
+        "group": "Branch1",
+        "site": "Antigua",
+        "version": "WC.16.11.0012",
+        "uplk ports": [
+          {
+            "port": "8"
+          }
+        ],
+        "type": "ArubaSwitch",
+        "public ip": "1.1.1.1"
+    },
+    "rate_limit_switch": {
+        "serial": "TW1AKGF123"          # This should be a 48 port PoE CX switch, can be the same as the "switch" defined above, but doesn't have to be
+    },
     "ap": {
+        "name": "ant-315.0c88-ap",
         "type": "ap",
         "version": "8.7.1.1_78245",
         "group": "Branch1",
-        "ip": "10.101.6.200",
+        "ip": "10.2.30.6",
         "labels": "Branch_View",
-        "mac": "A8bd.27c0.aabb",
+        "mac": "A9cd.13d0.0a88",
         "model": "315",
-        "name": "BR1_315_0c:88",
-        "serial": "CNC7J0T0GK",
+        "serial": "TWC8K0S0HK",
         "site": "Antigua",
         "status": "Up"
-        },
+    },
     "gateway": {
         "type": "gateway",
         "version": "8.6.0.4-2.2.0.3_77966",
-        "group": "WadeLab",
-        "ip": "192.168.30.202",
+        "group": "VPNC",
+        "ip": "172.30.0.243",
         "labels": "Branch_View",
-        "mac": "20-4c-03-2f-f9-54",
+        "mac": "aa-cc-ee-bb-dd-ff",
         "model": "A7005",
         "name": "VPNC2",
-        "serial": "CP0044573",
+        "serial": "CP1234546",
         "site": "WadeLab",
         "status": "Up"
-        },
+    },
     "template": {
         "device_type": "ArubaSwitch",
         "group": "Branch1",
         "model": "JL258A",
         "name": "2930F-8",
-        "template_hash": "a96df8da936389e5b71fd52d4bcb3464",
+        "template_hash": "de9419A16d6eeb4e9b75617a4249896f",
         "version": "ALL"
+    },
+    "batch": {
+        "sites": [
+            {
+                "site_name": "cencli_test_site1",
+                "site_address": {
+                    "address": "123 test ave",
+                    "city": "Nashville",
+                    "state": "TN"
+                }
+            },
+            {
+                "site_name": "cencli_test_site2",
+                "geolocation": {
+                    "latitude": "44.18911852569872",
+                    "longitude": "-85.80498510653379"
+                }
+            }
+        ]
+    },
+    "clone": {
+        "to_group": "TESTING"
+    },
+    "client": {
+        "wireless": {
+            "name": "ofc-light",
+            "mac": "2542.c11d.aabb"
+        },
+        "wired": {
+            "name": "ZAG1234567",
+            "alias": "uxi-barn",
+            "mac": "20:4c:03:00:00:00"
         }
+    },
+    "update": {},
+    "mpsk_ssid": "Aruba-MPSK"
 }

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -24,7 +24,7 @@ def cleanup():
     yield do_nothing()
     # executed after test is run
     result = runner.invoke(app, ["show", "cache", "groups", "--json"])
-    del_groups = [g["name"] for g in json.loads(result.stdout) if g["name"].startswith("cencli_test_") or g["name"] == "TESTING"]
+    del_groups = [g["name"] for g in json.loads(result.stdout) if g["name"].startswith("cencli_test_")]
     if del_groups:
         result = runner.invoke(app, ["delete", "group", *del_groups, "-Y"])
         assert "Success" in result.stdout
@@ -69,6 +69,7 @@ def test_blink_wrong_dev_type():
     assert "excluded" in result.stdout
 
 
+# This group remains as it is deleted in cleanup of test_update
 def test_clone_group(cleanup):
     result = runner.invoke(app, ["-d", "clone", "group", TEST_DEVICES["gateway"]["group"], TEST_DEVICES["clone"]["to_group"], "-Y"])
     assert result.exit_code == 0

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -24,7 +24,7 @@ def cleanup():
     yield do_nothing()
     # executed after test is run
     result = runner.invoke(app, ["show", "cache", "groups", "--json"])
-    del_groups = [g for g in json.loads(result.stdout) if g.startswith("cencli_test_") or g == "TESTING"]
+    del_groups = [g["name"] for g in json.loads(result.stdout) if g["name"].startswith("cencli_test_") or g["name"] == "TESTING"]
     if del_groups:
         result = runner.invoke(app, ["delete", "group", *del_groups, "-Y"])
         assert "Success" in result.stdout

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -1,17 +1,12 @@
-from pathlib import Path
 from typer.testing import CliRunner
 import pytest
 
 from cli import app  # type: ignore # NoQA
+from . import test_data
 import json
 
-# from . import TEST_DEVICES
 
 runner = CliRunner()
-
-test_dev_file = Path(__file__).parent / 'test_devices.json'
-if test_dev_file.is_file():
-    TEST_DEVICES = json.loads(test_dev_file.read_text())
 
 
 def do_nothing():
@@ -31,23 +26,23 @@ def cleanup():
         assert result.exit_code == 0
 
 def test_bounce_interface():
-    result = runner.invoke(app, ["bounce",  "interface", TEST_DEVICES["switch"]["name"].lower(),
-                           TEST_DEVICES["switch"]["test_port"], "-Y", "--debug"])
+    result = runner.invoke(app, ["bounce",  "interface", test_data["switch"]["name"].lower(),
+                           test_data["switch"]["test_port"], "-Y", "--debug"])
     assert result.exit_code == 0
     assert "state:" in result.stdout
     assert "task_id:" in result.stdout
 
 
 def test_bounce_poe():
-    result = runner.invoke(app, ["bounce", "poe", TEST_DEVICES["switch"]["name"].lower(),
-                           TEST_DEVICES["switch"]["test_port"], "-Y", "--debug"])
+    result = runner.invoke(app, ["bounce", "poe", test_data["switch"]["name"].lower(),
+                           test_data["switch"]["test_port"], "-Y", "--debug"])
     assert result.exit_code == 0
     assert "state:" in result.stdout
     assert "task_id:" in result.stdout
 
 
 def test_blink_switch():
-    result = runner.invoke(app, ["blink", TEST_DEVICES["switch"]["name"].lower(),
+    result = runner.invoke(app, ["blink", test_data["switch"]["name"].lower(),
                            "on", "-Y"])
     assert result.exit_code == 0
     assert "state:" in result.stdout
@@ -59,7 +54,7 @@ def test_blink_wrong_dev_type():
         app,
         [
             "blink",
-            TEST_DEVICES["gateway"]["mac"],
+            test_data["gateway"]["mac"],
             "on",
             "-Y"
         ]
@@ -71,15 +66,8 @@ def test_blink_wrong_dev_type():
 
 # This group remains as it is deleted in cleanup of test_update
 def test_clone_group(cleanup):
-    result = runner.invoke(app, ["-d", "clone", "group", TEST_DEVICES["gateway"]["group"], TEST_DEVICES["clone"]["to_group"], "-Y"])
-    assert result.exit_code == 0
-    assert "201" in result.stdout
-    assert "Created" in result.stdout
-    # cleanup()
+    result = runner.invoke(app, ["-d", "clone", "group", test_data["gateway"]["group"], test_data["clone"]["to_group"], "-Y"])
+    assert result.exit_code == 0  # TODO check this we are not returning a 1 exit_code on resp.ok = False?
+    assert "201" in result.stdout or "400" in result.stdout
+    assert "Created" in result.stdout or "already exists" in result.stdout
 
-
-# def test_do_move_dev_to_group():
-#     result = runner.invoke(app, ["do", "move", "J9773A-80:C1:6E:CD:32:40",
-#                            "wadelab", "-Y", "--debug"])
-#     assert result.exit_code == 0
-#     assert "Success" in result.stdout

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,42 +1,31 @@
 import logging
-from pathlib import Path
-# from typer.testing import CliRunner
+import time
+from rich import print
+from . import common, log, test_data
 
-# from cli import app  # type: ignore # NoQA
-# import json
-# from pathlib import Path
+central = common.central
 
-# from . import TEST_DEVICES
-
-# runner = CliRunner()
-
-# test_dev_file = Path(__file__).parent / 'test_devices.json'
-# if test_dev_file.is_file():
-#     TEST_DEVICES = json.loads(test_dev_file.read_text())
-import sys
-from pendulum import time
-try:
-    from centralcli import (
-        central, log
-    )
-except (ImportError, ModuleNotFoundError) as e:
-    pkg_dir = Path(__file__).absolute().parent.parent / "centralcli"
-    if pkg_dir.name == "centralcli":
-        sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import (
-            central, log
-        )
-    else:
-        print(pkg_dir.parts)
-        raise e
+# try:
+#     from centralcli import (
+#         central, log
+#     )
+# except (ImportError, ModuleNotFoundError) as e:
+#     pkg_dir = Path(__file__).absolute().parent.parent / "centralcli"
+#     if pkg_dir.name == "centralcli":
+#         sys.path.insert(0, str(pkg_dir.parent))
+#         from centralcli import (
+#             central, log
+#         )
+#     else:
+#         print(pkg_dir.parts)
+#         raise e
 
 log.setLevel(logging.DEBUG)
-from rich import print
-import time
+
 
 def test_rate_limit():
     log._DEBUG = True
-    b_reqs = [central.BatchRequest(central.get_switch_poe_details, "TW0BKNF063", port=f"1/1/{p}") for p in range(1, 49)]
+    b_reqs = [central.BatchRequest(central.get_switch_poe_details, test_data["rate_limit_switch"]["serial"], port=f"1/1/{p}") for p in range(1, 49)]
     start = time.perf_counter()
     b_resp = central.batch_request(b_reqs)
     end = time.perf_counter() - start
@@ -51,7 +40,7 @@ def test_rate_limit():
     if rate_limit_failures:
         print(f"[bright_red]!![/] Rate Limit Failures {len(rate_limit_failures)}")
     assert len(failed) == len(successful_retries)
-    assert len(b_reqs) == len([r for r in central.requests if r.ok])
+    assert len(b_reqs) == len([r for r in central.requests if r.ok and "poe_detail" in r.url])
     assert len (rate_limit_failures) == 0
     assert len(failed) < 2
 

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -235,10 +235,10 @@ def test_show_lldp_by_ap_name():
 
 
 def test_show_groups():
-    result = runner.invoke(app, ["show", "groups"],)
+    result = runner.invoke(app, ["show", "groups", "--csv"],)
     assert result.exit_code == 0
     assert "name" in result.stdout
-    assert "template group" in result.stdout
+    assert "AOSVersion" in result.stdout
 
 
 def test_show_certs():

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -46,15 +46,15 @@ def test_show_all():
     assert "serial" in result.stdout
 
 
-def test_show_all_w_client_counts():
+def test_show_all_w_stats():
     """We Use csv output as rich will truncate cols and clients is last col
 
     tty size for test runner is 80 cols, 24 rows
     """
-    result = runner.invoke(app, ["show", "all", "--clients", "--csv"],)
+    result = runner.invoke(app, ["show", "all", "--stats", "--csv"],)
     assert result.exit_code == 0
     assert "serial" in result.stdout.splitlines()[0]
-    assert "clients" in result.stdout.splitlines()[0]
+    assert "cpu %" in result.stdout.splitlines()[0]
 
 
 def test_show_switch_by_name():
@@ -266,10 +266,10 @@ def test_show_switch_vlans_by_name():
     assert "pvid" in result.stdout
 
 
-def test_show_events_past():
-    result = runner.invoke(app, ["show", "events", "--past", "30m"],)
+def test_show_logs_past():
+    result = runner.invoke(app, ["show", "logs", "--past", "30m"],)
     assert result.exit_code == 0
-    assert "Event Logs" in result.stdout
+    assert "event logs" in result.stdout.lower()
     assert "description" in result.stdout
 
 


### PR DESCRIPTION

💥 BREAKING CHANGE get_all_groups is now an aggregator which combines template_info and properties for groups after calling get_group_names
✨ 🎉 `cencli bounce` now supports interface ranges.
✅ ♻️ Refactor / Improve test.  Add test setup.  Add verification that test is running on intended account.
💬 Update default format in show_devices when a device is specified
🔧 Update test_devices example
✨ Update tshoot command device completion to by return only supported switch types for the command.
✅ Add test for mpsk completion
✨ Add `cencli show mpsk networks`
✨ Add `cencli show mpsk named <SSID>`
🗃️ Add MPSK SSID and IDs to cache.  Add completion for mpsk SSIDs
✨ Add mpsk download as csv method
✨ Add `batch add macs|mpsk`
✨ Add `show cloud-auth upload`
💬 Adjust show inventory cleaner
✨ Add site verification to `batch verify`
💬 Add caption with counts to show aps | gateways | switches
💬 Add caption with total count to `show cloud-auth registered-macs`
✨ All device commands have a sensible non-verbose brief listing, and support `-v` for full details.
🗃️ cache now includes switch_role to determine stack conductor
✨ Improve some commands where a switch is provided, if the specified switch is a stack, return the results
  from the conductor vs. having you select switch from the multiple matches (if name was used to identify the switch)
✨ show devices default for json/yaml will be to concatinate name-serial for the key when converting List[dict] to Dict.
  This is necessary to make key unique for stack members.
🧑‍💻 Allow output_by_key to pass a string with a + indicating we will make a new key made up of that values of those keys concatinated.
    Otherwise "name+serial" will result in "devname-devserial": dict
✨ Improve show run, now returns running config from the device itself via troubleshooting commands.
💬 Improve formatting of config file output (highlight)
✨ Add sort and completion for sort to `show groups`
✨ `show groups` now shows more info by default.
⚡ Change default for show logs to past 30m
🧑‍💻 remove underscore preceding _get_group_names it's not used by any commands in the CLI directly, but when using centralcli as a
  library it's shouldn't be considered an internal method.
🗃️ fix update_dev_db when returning results from API (deepcopy so formatting from cache does not update the resp.output returned (keep it in original form)
✨ Add `cencli show cluster <group> <ssid>`
✨ Improve `show wlans --group <GROUP>`
💬 Improve help text, and update tshoot commands to use dev_type (vs generic_dev_type)
✨ `show poe` now has a cleaner and a default "brief" display, supports `-v` (verbose) for full details.
🧑‍💻 get_dev_identifier now supports all device types (vs. generic device type... otherwise `switch` can still be used to indicate cx or sw,
  but you can now send `cx` which would ignore `sw` matches)
💬  Sort output of `show lldp ...` by interface when output is for CX.
✨ simplify show interfaces, add stacks to show lldp
🧑‍💻 Support morphing list to dict by provided key (still defaults to name)
💬 Add switch lldp neighbor logic to lldp cleaner, Support stacks in show_interfaces cleaner
🧑‍💻 get_dev_identifier now supports swack: bool, and conductor_only: bool options
  - `swack: bool = False` if set to True will only return value if the match is the conductor, or VC in the case of swarm
  - `conductor_only: bool = False` if set to True will return only the conductor of resulting matched stacks, but will also return any non stack matches.  Otherwise it's like swack, but swack will *only* return matches that are the conductor, where conductor_only will return all matches, only filtering out member (non conductor) switches if a match happens to be a stack.
✨ Add `show stacks`
✨ Add `--table` (alternative table format) to `cencli show cache`
🐛 Fix bug in tabulate output when a dict included a sub-dict.
🐛 Pass params for API call to update_dev_db
🐛 Fix missing client_count when `-v` is used with `show all`