### PR TITLE
🔖 v5.1.0

### DIFF
--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -140,9 +140,9 @@ if os.environ.get("TERM_PROGRAM") == "vscode":
     vscode_arg_handler()
 
 raw_out = False
-if "-vv" in sys.argv:
+if "--raw" in sys.argv:
     raw_out = True
-    _ = sys.argv.pop(sys.argv.index("-vv"))
+    _ = sys.argv.pop(sys.argv.index("--raw"))
 if "--debug-limit" in sys.argv:
     _idx = sys.argv.index("--debug-limit")
     _ = sys.argv.pop(sys.argv.index("--debug-limit"))

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -71,7 +71,7 @@ class CentralObject:
         data: Union[list, Dict[str, Any]],
     ) -> Union[list, Dict[str, Any]]:
         self.is_dev, self.is_template, self.is_group, self.is_site, self.is_label = False, False, False, False, False
-        data = None if not data else data
+        data: Dict | List[dict] = None if not data else data
         setattr(self, f"is_{db}", True)
         self.cache = db
 
@@ -91,6 +91,7 @@ class CentralObject:
             self.ip = self.data["ip"] = self.data.get("ip")
             self.site = self.data["site"] = self.data.get("site")
             self.swack_id = self.data["swack_id"] = self.data.get("swack_id")
+            self.serial: str = self.data.get("serial")
 
     def __bool__(self):
         return bool(self.data)

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -23,13 +23,11 @@ try:
 except Exception:
     pass
 
-# TODO remove after TESTING NEW string matching lookup
 try:
     from fuzzywuzzy import process  # type: ignore noqa
     FUZZ = True
 except Exception:
     FUZZ = False
-    pass
 
 # Used to debug completion
 err_console = Console(stderr=True)

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -5235,6 +5235,22 @@ class CentralApi(Session):
 
         return await self.get(url, params=params)
 
+    async def get_portal_profile(
+        self,
+        portal_id: str,
+    ) -> Response:
+        """Get guest portal profile.
+
+        Args:
+            portal_id (str): Portal ID of the splash page
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = f"/guest/v1/portals/{portal_id}"
+
+        return await self.get(url)
+
     async def get_visitors(
         self,
         portal_id: str,

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -31,7 +31,7 @@ except (ImportError, ModuleNotFoundError) as e:
         print(pkg_dir.parts)
         raise e
 
-from centralcli.constants import DevTypes, StatusOptions
+from centralcli.constants import DevTypes, StatusOptions, LLDPCapabilityTypes
 from centralcli.objects import DateTime
 from centralcli.models import CloudAuthUploadResponse
 
@@ -233,6 +233,11 @@ _short_value = {
     "disable_ssid": lambda v: '✅' if not v else '❌', # field is changed to "enabled" check: \u2705 x: \u274c
     "poe_detection_status": lambda i: constants.PoEDetectionStatus(i).name,
     "reserved_power_in_watts": lambda v: round(v, 2),
+    "speed": lambda v: "1000BaseT FD" if v == "1000BaseTFD - Four-pair Category 5 UTP, full duplex mode" else v,
+    "ec": lambda v: v if not isinstance(v, list) else ", ".join([LLDPCapabilityTypes(ec).name.replace("_", " ") for ec in v]),
+    "sc": lambda v: v if not isinstance(v, list) else ", ".join([LLDPCapabilityTypes(ec).name.replace("_", " ") for ec in v]),
+    "chassis_id_type": lambda v: None,
+    "chassis_id_type_str": lambda v: None,
     # "enabled": lambda v: not v, # field is changed to "enabled"
     # "allowed_vlan": lambda v: str(sorted(v)).replace(" ", "").strip("[]")
 }
@@ -312,6 +317,9 @@ _short_key = {
     "power_class": "class",
     "cluster_group_name": "group",
     "cluster_redundancy_type": "redundancy type",
+    "ec": "enabled capabilities",
+    "sc": "system capabilities",
+    "ec_str": "enabled capabilities"
 }
 
 
@@ -1018,11 +1026,12 @@ def get_lldp_neighbor(data: List[Dict[str, str]]) -> Dict[str: Dict[str, str]]:
         "1000BaseTFD - Four-pair Category 5 UTP, full duplex mode": "1000BaseT FD"
     }
     # grab the key details from switch lldp return, make data look closer to lldp return from AP
+
     if data and "dn" in data[0].keys():
         data = [{**dict(d if "dn" not in d else d["dn"]), "vlan_id": ",".join(d.get("vlan_id", [])), "lldp_poe": d.get("lldp_poe_enabled")} for d in data]
         data = sort_interfaces(data, interface_key="port")
     # simplify some of the values and strip the bond0 entry from AP
-    data = [{k: _short_val.get(d[k], d[k]) for k in d if d.get("localPort", "") != "bond0" and k not in strip_keys} for d in data]
+    data = [dict(short_value(k, d[k]) for k in d if d.get("localPort", "") != "bond0" and k not in strip_keys) for d in data]
 
     return strip_no_value(data)
 

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1419,6 +1419,12 @@ def get_portals(data: List[dict],) -> List[dict]:
 
     return data
 
+
+def get_portal_profile(data: List[Dict[str, Any]]) -> Dict[str, Any]:
+    # _display_output will listify the dict prior to sending it in as most outputs are List[dict]
+    data = utils.unlistify(data)
+    return {k: v for k, v in data.items() if k != "logo"}
+
 def get_ospf_neighbor(data: Union[List[dict], dict],) -> Union[List[dict], dict]:
     data = utils.listify(data)
 

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -892,6 +892,7 @@ def convert(
 
 
 def all_commands_callback(ctx: typer.Context, update_cache: bool):
+    # --raw and --debug-limit are honored and stripped out in init
     if ctx.resilient_parsing:
         config.is_completion = True
     if not ctx.resilient_parsing:

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -492,7 +492,7 @@ def nuke(
     else:  # AP all others will error in get_dev_identifier
         func = cli.central.send_command_to_swarm
         arg = dev.swack_id
-        if dev.version.startswith("10."):  # TODO add aos8 vs aos10 flag to dev cache
+        if dev.version.startswith("10."):
             cli.exit("This command is only valid for [cyan]AOS8[/] IAP clusters not [cyan]AOS10[/] APs")
         elif not swarm:
             cli.exit("This command is only valid for the entire swarm in AOS8, not individual APs.  Use [green]-s[/]|[cyan]--swarm[/] to default the entire IAP cluster")

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -927,8 +927,6 @@ def all_commands_callback(ctx: typer.Context, update_cache: bool):
                 err_console.print(f":warning:  Both [cyan]-d[/] and [cyan]--account[/] flag used.  Honoring [cyan]-d[/], ignoring account [cyan]{account}[/]")
                 account = config.default_account
             cli.account_name_callback(ctx, account=config.default_account, default=True)
-            # default = cli.default_callback(ctx, True)
-        # elif account:
         else:
             cli.account_name_callback(ctx, account=account)
 

--- a/centralcli/cliclone.py
+++ b/centralcli/cliclone.py
@@ -30,19 +30,16 @@ def group(
     clone_group: str = typer.Argument(..., metavar="[NAME OF GROUP TO CLONE]", autocompletion=cli.cache.group_completion),
     new_group: str = typer.Argument(..., metavar="[NAME OF GROUP TO CREATE]"),
     aos10: bool = typer.Option(None, "--aos10", help="Upgrade new cloned group to AOS10"),
-    yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),
-    yes_: bool = typer.Option(False, "-y", hidden=True),
+    yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",
                                callback=cli.debug_callback),
-    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
-                                 callback=cli.default_callback),
-    account: str = typer.Option("central_info",
-                                envvar="ARUBACLI_ACCOUNT",
-                                help="The Aruba Central Account to use (must be defined in the config)",
-                                callback=cli.account_name_callback),
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+    ),
 ) -> None:
-    yes = yes_ if yes_ else yes
-
     print(f"Clone group: {color(clone_group)} to new group {color(new_group)}")
     if aos10:
         print(f"    Upgrade cloned group to AOS10: {color(True)}")

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -329,13 +329,16 @@ class CLICommon:
                 log.warning(out_msg, show=True)
 
     @staticmethod
-    def exit(msg: str, code: int = 1) -> None:
-        """Print error text and exit.
+    def exit(msg: str = None, code: int = 1) -> None:
+        """Print msg text and exit.
+
+        Prepends warning emoji to msg if code indicates an error.
         """
         if code != 0:
-            msg = f":warning:  {msg}"
+            msg = f":warning:  {msg}" if msg else msg
 
-        print(msg)
+        if msg:
+            print(msg)
         raise typer.Exit(code=code)
 
     def _display_results(

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -1505,7 +1505,6 @@ def lldp(
     """
     central = cli.central
 
-    # TODO need get_dev_identier to accept cx
     devs: List[CentralObject] = [cli.cache.get_dev_identifier(_dev, dev_type=("ap", "switch"), conductor_only=True,) for _dev in device if not _dev.lower().startswith("neighbor")]
     batch_reqs = [BatchRequest(central.get_ap_lldp_neighbor, (dev.serial,)) for dev in devs if dev.type == "ap"]
     batch_reqs += [BatchRequest(central.get_cx_switch_neighbors, (dev.serial,)) for dev in devs if dev.generic_type == "switch" and not dev.swack_id]
@@ -1526,6 +1525,7 @@ def lldp(
             r,
             tablefmt=tablefmt,
             title=title,
+            caption = "  :warning:  [italic dark_olive_green2]AOS-SW only reflects LLDP neighbors that are managed by Aruba Central[/]" if dev.type == "sw" else None,
             pager=pager,
             outfile=outfile,
             output_by_key=["port", "localPort"],

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2989,9 +2989,10 @@ def archived(
     cli.display_results(resp, tablefmt="yaml")
 
 
-# TODO cahce portal/name ids
+# TODO sort_by / reverse tablefmt options add verbosity 1 to cleaner
 @app.command()
 def portals(
+    portal: str = typer.Argument(None, metavar="[name|id]", help="show details for a specific portal profile [grey42]\[default: show summary for all portals][/]", show_default=False,),
     default: bool = typer.Option(
         False, "-d", is_flag=True, help="Use default central account", show_default=False,
     ),
@@ -3005,9 +3006,16 @@ def portals(
         autocompletion=cli.cache.account_completion,
     ),
 ) -> None:
-    """Show Configured Guest Portals"""
-    resp = cli.central.request(cli.central.get_portals)
-    cli.display_results(resp, cleaner=cleaner.get_portals, fold_cols=["url"],)
+    """Show Configured Guest Portals or details for a specific portal"""
+    if portal is None:
+        resp: Response = cli.central.request(cli.cache.update_portal_db)
+        _cleaner = cleaner.get_portals
+    else:
+        p: CentralObject = cli.cache.get_name_id_identifier("portal", portal)
+        resp: Response = cli.central.request(cli.central.get_portal_profile, p.id)
+        _cleaner = None
+
+    cli.display_results(resp, tablefmt="yaml" if portal else "rich", cleaner=_cleaner, fold_cols=["url"],)
 
 
 # TODO add sort_by completion

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -1499,7 +1499,9 @@ def lldp(
     """Show AP lldp neighbor
 
     Valid on APs and CX switches
-    Command will run on AOS-SW, but neighbor table will only show neighbors that are CX switches or APs
+
+    Use [cyan]cencli show aps -n --site <SITE>[/] to see lldp neighbors for all APs in a site.
+    NOTE: AOS-SW will return LLDP neighbors, but only it reports neighbors for connected Aruba devices managed in Central
     """
     central = cli.central
 

--- a/centralcli/clitshoot.py
+++ b/centralcli/clitshoot.py
@@ -55,15 +55,17 @@ def send_cmds_by_id(device: CentralObject, commands: List[int], pager: bool = Fa
             _delay = 15 if device.type == "cx" else 10
             for _ in track(range(_delay), description="[green]Allowing time for commands to complete[/]..."):
                 sleep(1)
-            # with console.status("Waiting for Troubleshooting Response..."):
-            #     sleep(10)
+
             ts_resp = cli.central.request(cli.central.get_ts_output, device.serial, resp.session_id)
 
             if ts_resp.output.get("status", "") == "COMPLETED":
                 lines = "\n".join([line for line in ts_resp.output["output"].splitlines() if line != " "])
                 ts_resp.raw = ts_resp.output["output"]
                 ts_resp.output = lines
-                cli.display_results(ts_resp, pager=pager, outfile=outfile)
+                show_tech_ap = [115, 369, 465]
+                tablefmt = "clean" if sorted(commands) != show_tech_ap else "raw"
+
+                cli.display_results(ts_resp, pager=pager, outfile=outfile, tablefmt=tablefmt)
                 complete = True
                 break
             else:

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -14,12 +14,12 @@ import asyncio
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import utils, cli, caas, cleaner, config
+    from centralcli import utils, cli, caas, cleaner
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import utils, cli, caas, cleaner, config
+        from centralcli import utils, cli, caas, cleaner
     else:
         print(pkg_dir.parts)
         raise e

--- a/centralcli/cliupgrade.py
+++ b/centralcli/cliupgrade.py
@@ -64,7 +64,7 @@ def device(
 ) -> None:
     """Upgrade firmware on a device
     """
-    dev = cli.cache.get_dev_identifier(device, swack=True)
+    dev = cli.cache.get_dev_identifier(device, conductor_only=True)
     if dev.generic_type == "ap":
         reboot = True
     at = None if not at else int(round(at.timestamp()))

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -299,6 +299,7 @@ class CacheArgs(str, Enum):
     hook_data = "hook_data"
     hook_active = "hook_active"
     mpsk = "mpsk"
+    portals = "portals"
 
 
 class KickArgs(str, Enum):

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -47,13 +47,30 @@ class SendConfigDevIdens(str, Enum):
     # sw = "sw"  # hopefully some day
     # cx = "cx"
 
-
 class PoEDetectionStatus(Enum):
     NA = 0
     Undefined = 1  # TODO figure out what this status is
     Searching = 2
     Delivering = 3
 
+# Here are all the types for the below Enum
+# 3: Bridge (Switch)
+# DOCSIS Cable Device
+# Other
+# Repeater
+# 5 but think 5: Router
+# Station
+# Telephone
+# 4: WLAN Access Point
+class LLDPCapabilityTypes(Enum):
+    unknown0 = 0
+    unknown1 = 1
+    unknown2 = 2
+    Bridge = 3  # 3 and 5 are assumption need to verify
+    Wlan_Access_Point = 4
+    Router = 5
+    unknown6 = 6
+    unknown7 = 7
 
 # Not used currently # TODO reference in cleaner
 class SwitchRoles(Enum):

--- a/centralcli/logger.py
+++ b/centralcli/logger.py
@@ -101,7 +101,6 @@ class MyLogger:
             return "\n".join([f'  {msg}' for msg in self._caption])
 
     def log_print(self, msgs, log: bool = False, show: bool = False, caption: bool = False, level: str = 'info', *args, **kwargs):
-        # TODO can prob remove log_msgs, used by another project I re-used this object from (ConsolePi)
         msgs = [msgs] if not isinstance(msgs, list) else msgs
         _msgs = []
         _logged = []
@@ -120,7 +119,7 @@ class MyLogger:
             self.log_msgs += _msgs
             for m in self.log_msgs:
                 if console.is_terminal or environ.get("PYTEST_CURRENT_TEST"):
-                    emoji_console.print(f"{':warning:  ' if not level=='info' else ''}{m}")
+                    emoji_console.print(f"{':warning:  ' if level not in ['info', 'debug'] else ''}{m}")
             self.log_msgs = []
 
         if caption:

--- a/centralcli/models.py
+++ b/centralcli/models.py
@@ -611,3 +611,20 @@ class CacheMpskNetwork(BaseModel):
 
 class CacheMpskNetworks(BaseModel):
     items: List[CacheMpskNetwork]
+
+
+class CachePortal(BaseModel):
+    name: str
+    id: str
+    url: str = Field(alias="capture_url")
+    auth_type: str
+    is_aruba_cert: bool
+    is_default: bool
+    is_editable: bool
+    is_shared: bool
+    register_accept_email: bool
+    register_accept_phone: bool
+
+
+class CachePortals(BaseModel):
+    portals: List[CachePortal]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.0.0"
+version = "5.1.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
🚩 Change global hidden command for raw output display from `-vv` to `--raw`
⚡ `tshoot show-tech` now renders using "clean" option to bypass formatters.
💬 Improve output options in `show tshoot results`, Add `clean` argument to display output without running it through any formatters.
✨ Add cx and sw support to `show config`
💬 Improve/update help text for `show config`
🥅 Make Output classes file property more bullet proof
🧑‍💻 Add tablfmt="clean" option to print output without running it through any formatters.
🐛 Fix account callbacks in `cencli clone`
✨ Add `--logo [PATH]` option to `show portals` to download portal logo to file
✨ Add `show portals <portal name|id>` and cache for portals
💬 Caption for inventory, and improve logic for all show_device captions
💩 _build_caption is too complex, functions, but not elegant, too long/complex... needs to be simplified
💬 Add caption explaining limitation with lldp response from cx devices.
💬 Remove emoji from `cencli move` confirmation and error messages to avoid conflict with MAC addresses.
💬 remove warning emoji from debug logs printed to screen.
💬 Update `show lldp` help text
🐛 Fix issue with AOS-SW LLDP neighbors, improve formatting of `show lldp <device>` output
🩹 Update `upgrade device` to use conductor_only param vs swack (which will likely be deprecated).