### PR TITLE
:poop: remove click pin for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # cencli requirements
 # cchardet
 colorama>=0.4.6
-click<=7.1.2
+click
 pygments>=2.17.2
 tabulate>=0.9.0
 halo>=0.0.31


### PR DESCRIPTION
typer is installing typer-slim which has a different click dep

click pin is for the sake of completion, which shouldn't impact docs build