### PR TITLE
🔖 v5.2.1

### DIFF
--- a/centralcli/__init__.py
+++ b/centralcli/__init__.py
@@ -149,9 +149,10 @@ if "--debug-limit" in sys.argv:
     if len(sys.argv) - 1 >= _idx and sys.argv[_idx].isdigit():
         config.limit = int(sys.argv[_idx])
         _ = sys.argv.pop(_idx)
-    else:
-        print(f"Invalid Value ({sys.argv[_idx]}) for --debug-limit expected an int")
-        sys.exit(1)
+if "--sanitize" in sys.argv:
+    _ = sys.argv.pop(sys.argv.index("--sanitize"))
+    config.sanitize = True
+
 
 central = CentralApi(config.account)
 cache = Cache(central)

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -735,7 +735,7 @@ def batch_add_devices(import_file: Path = None, data: dict = None, yes: bool = F
             except ValidationError as e:
                 log.info(f"Performing full cache update after batch add devices as import_file data validation failed. {e}")
                 _data = None
-        # asyncio.run(cli.cache.update_inv_db(data=_data))
+
         # always perform full dev_db update as we don't know the other fields.
         console = Console()
         with console.status(f'Performing{" full" if _data else ""} inventory cache update after device edition.'):
@@ -1014,8 +1014,6 @@ def add(
     ),
 ) -> None:
     """Perform batch Add operations using import data from file
-
-
     """
     if show_example:
         print(getattr(examples, f"add_{what}"))

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -894,7 +894,7 @@ def verify(
 
         if file_by_serial[s].get("site"):
             if not central_by_serial[s].get("status"):
-                validation[s] += [f"{_pfx}  Also unable to assign site prior to device checking in."]
+                validation[s] += [f"{_pfx}Unable to assign/verify site prior to device checking in."]
             elif not central_by_serial[s].get("site"):
                 validation[s] += [f"{_pfx}Site: [cyan]{file_by_serial[s]['site']}[/] from import != [italic]None[/] reflected in Central."]
             elif file_by_serial[s]["site"] != central_by_serial[s]["site"]:
@@ -903,7 +903,7 @@ def verify(
         if file_key:
             _pfx = "" if _pfx in str(validation[s]) else _pfx
             if file_by_serial[s][file_key] != central_by_serial[s]["services"]: # .replace("-", "_").replace(" ", "_")
-                validation[s] += [f"{_pfx}License: [bright_red]{file_by_serial[s][file_key]}[/] from import != [bright_green]{central_by_serial[s]['services']}[/] reflected in Central."]
+                validation[s] += [f"{_pfx}Subscription: [bright_red]{file_by_serial[s][file_key]}[/] from import != [bright_green]{central_by_serial[s]['services'] or 'No Subscription Assigned'}[/] reflected in Central."]
 
     ok_devs, not_ok_devs = [], []
     for s in file_by_serial:
@@ -1039,6 +1039,9 @@ def add(
         cleaner = cleaner.parse_caas_response
     elif what == "devices":
         resp = batch_add_devices(import_file, yes=yes)
+        if [r for r in resp if not r.ok and r.url.path.endswith("/subscriptions/assign")]:
+            log.warning("Aruba Central took issue with some of the devices when attempting to assign subscription.  It will typically stop processing when this occurs, meaning valid devices may not have their license assigned.", caption=True)
+            log.info(f"Use [cyan]cencli batch verify {import_file}[/] to check status of license assignment.", caption=True, log=False)
     elif what == "labels":
         resp = batch_add_labels(import_file, yes=yes)
     elif what == "macs":
@@ -1164,6 +1167,10 @@ def batch_delete_devices(data: list | dict, *, ui_only: bool = False, cop_inv_on
     # TODO Literally copy/paste from clidel.py (then modified)... maybe move some things to clishared or clicommon
     # to avoid duplication ... # FIXME update clidel with corrections made below
     cache_devs: List[CentralObject | None] = [cli.cache.get_dev_identifier(d, silent=True, include_inventory=True, exit_on_fail=False) for d in serials_in]  # returns None if device not found in cache after update
+    if len(serials_in) != len(cache_devs):
+        log.warning(f"DEV NOTE: Error len(serials_in) ({len(serials_in)}) != len(cache_devs) ({len(cache_devs)})", show=True)
+    else:
+        log.warning(f"DEV NOTE: Error len(serials_in) ({len(serials_in)}) != len(cache_devs) ({len(cache_devs)})", show=True)
     not_in_inventory: List[str] = [d for d, c in zip(serials_in, cache_devs) if c is None]
     cache_devs: List[CentralObject] = [c for c in cache_devs if c]
     _all_in_inventory: Dict[str, Document] = cli.cache.inventory_by_serial

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -92,7 +92,7 @@ def _build_caption(resp: Response, *, inventory: bool = False, dev_type: Generic
                 status_by_type[t] = {"total": counts.total, "up": counts.up, "down": counts.down, "inventory_only": counts.inventory}
 
         else:  # show all [--inv], or show ivnentory -v
-            counts_by_type = {**{k: {"total": resp.raw[k][0]["total"], "up": len(list(filter(lambda x: x["status"], resp.raw[k][0][k if k != "gateways" or not config.is_cop else "mcs"])))} for k in resp.raw.keys() if k != "switches"}, **get_switch_counts(resp.raw["switches"][0]["switches"])}
+            counts_by_type = {**{k: {"total": resp.raw[k][0]["total"], "up": len(list(filter(lambda x: x["status"] == "Up", resp.raw[k][0][k if k != "gateways" or not config.is_cop else "mcs"])))} for k in resp.raw.keys() if k != "switches"}, **get_switch_counts(resp.raw["switches"][0]["switches"])}
             status_by_type = {LIB_DEV_TYPE.get(_type, _type): {"total": counts_by_type[_type]["total"], "up": counts_by_type[_type]["up"], "down": counts_by_type[_type]["total"] - counts_by_type[_type]["up"]} for _type in counts_by_type}
     elif dev_type == "switch":
         counts_by_type = get_switch_counts(resp.raw["switches"])

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -484,6 +484,7 @@ class ArgToWhat:
         self.switch = self.switch = self.switches = "switch"
         self.cx = "cx"
         self.mas = "mas"
+        self.ssid = self.ssids = "ssid"
 
     def _init_clone(self):
         self.group = self.groups = "group"

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -90,8 +90,8 @@ class Output:
             str: Sanitized str output with sensitive data redacted.
         """
         config = config or self.config
-        if config and config.sanitize and config.sanatize_file.is_file():
-            sanitize_data = config.get_file_data(config.sanatize_file)
+        if config and config.sanitize and config.sanitize_file.is_file():
+            sanitize_data = config.get_file_data(config.sanitize_file)
             for s in sanitize_data.get("redact_strings", {}):
                 strings = strings.replace(s, f"{'--redacted--':{len(s)}}")
             for s in sanitize_data.get("replace_strings", []):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.2.0"
+version = "5.2.1"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
  - 🚨 Non-impactful linter clean-up
  - 🧑‍💻 Make `--sanitize` a global (hidden) command line flag.
    - This is used to sanitize output for recording GIF demos, and pasting examples where you may want to mask out serial numbers, addresses, etc.
  - 🐛 fix `config.sanitize_file` variable typo
  - 🐛 fix `cencli tshoot ssid`
  - 💬 Improve batch verify output. Display warning if sub assignment on `batch add devices` returns an error.
  - 🐛 💬 fix show device caption counter (calculate up vs down correctly)