### PR TITLE
🔖 v5.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ centralcli/dashboard/*
 
 *.ignore
 centralcli/_*
+
+# ignore cnx allcalls file for now WiP
+cnx_allcalls.py

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -2784,6 +2784,8 @@ class CentralApi(Session):
         return await self.post(url, json_data=json_data)
 
     # API-FLAW add ap and gw to group with gw-role as wlan and upgrade to aos10.  Returns 200, but no changes made
+    # TODO need to add flag for SD_WAN_Gateway architecture (Silver Peak), only valid associated GwNetworkRole is VPNConcentrator
+    # TODO need to add SD_WAN_Gateway to AllowedDevTypes
     async def update_group_properties(
         self,
         group: str,
@@ -2794,7 +2796,7 @@ class CentralApi(Session):
         microbranch: bool = None,
         gw_role: constants.GatewayRole = None,
         monitor_only_sw: bool = None,
-        monitor_only_cx: bool = None,  # Not supported by central yet
+        monitor_only_cx: bool = None,
     ) -> Response:
         """Update properties for the given group.
 
@@ -2822,7 +2824,7 @@ class CentralApi(Session):
             microbranch (bool): True to enable Microbranch network role for APs is applicable only for AOS10 architecture.
             gw_role (GatewayRole): Gateway role valid values "branch", "vpnc", "wlan" ("wlan" only valid on AOS10 group)
             monitor_only_sw: Monitor only ArubaOS-SW switches, applies to UI group only
-            monitor_only_cx: Monitor only ArubaOS-CX switches, applies to UI group only (Future capability)
+            monitor_only_cx: Monitor only ArubaOS-CX switches, applies to UI group only
 
         Returns:
             Response: CentralAPI Response object
@@ -2906,7 +2908,6 @@ class CentralApi(Session):
             mon_only_switches += ["AOS_S"]
         if monitor_only_cx:
             mon_only_switches += ["AOS_CX"]
-            raise NotImplementedError("AOS_CX Monitor Only not supported in Central yet.")
 
         arch = None
         if microbranch is not None:

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -200,7 +200,7 @@ def group(
     cx: bool = typer.Option(None, "--cx", help="Allow ArubaOS-CX switches in group."),
     gw: bool = typer.Option(None, "--gw", help=f"Allow gateways in group.\n{' ':34}If No device types specified all are allowed."),
     mo_sw: bool = typer.Option(None, is_flag=True, help="Monitor Only for ArubaOS-SW"),
-    mo_cx: bool = typer.Option(None, help="Monitor Only for ArubaOS-CX", hidden=True),
+    mo_cx: bool = typer.Option(None, help="Monitor Only for ArubaOS-CX"),
     # ap_user: str = typer.Option("admin", help="Provide user for AP group"),  # TODO build func to update group pass
     # ap_passwd: str = typer.Option(None, help="Provide password for AP group (use single quotes)"),
     yes: bool = typer.Option(False, "-Y", help="Bypass confirmation prompts - Assume Yes"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.2.1"
+version = "5.2.2"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION

  - ✨ Allow mon_only for cx
  - ✨ Improve `cencli show aps --neighbors|-n --site <SITE>` (show AP LLDP neighbors for a site).
    - relies on response to determine what APs are in site, previously used cache.
    - Use switch IP from cache if payload has IP as "Unknown" (often the case) and the switch in question is in the cache.