### PR TITLE
🔖 v5.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ centralcli/dashboard/*
 
 *.ignore
 centralcli/_*
+
+# ignore cnx allcalls file for now WiP
+cnx_allcalls.py

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -1086,7 +1086,7 @@ class Cache:
             err_console.print(":warning:  Invalid config")
             return
 
-        match = self.get_dev_identifier(incomplete, device_type="gw", completion=True)
+        match = self.get_dev_identifier(incomplete, dev_type="gw", completion=True)
 
         out = []
         if match:

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -4041,7 +4041,7 @@ class CentralApi(Session):
         self,
         serial_num: str,
         api: str = "V1",
-        offset: int = 0,
+        marker: str = None,
         limit: int = 100
     ) -> Response:
         """Get routes for a device.
@@ -4049,7 +4049,7 @@ class CentralApi(Session):
         Args:
             serial_num (str): Device serial number
             api (str, optional): API version (V0|V1), Defaults to V1.
-            offset (str, optional): Pagination offset.
+            marker (str, optional): Pagination offset.
             limit (int, optional): page size Defaults to 100.
 
         Returns:
@@ -4060,7 +4060,7 @@ class CentralApi(Session):
         params = {
             'device': serial_num,
             'api': api,
-            'marker': offset,
+            'marker': marker,
             'limit': limit
         }
 

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -453,7 +453,7 @@ class CLICommon:
         data: Union[List[dict], List[str], dict, None] = None,
         tablefmt: TableFormat = "rich",
         title: str = None,
-        caption: str = None,
+        caption: str | List[str] = None,
         pager: bool = False,
         outfile: Path = None,
         sort_by: str = None,
@@ -481,7 +481,7 @@ class CLICommon:
                 clean bypasses all formatters.
             title: (str, optional): Title of output table.
                 Only applies to "rich" tablefmt. Defaults to None.
-            caption: (str, optional): Caption displayed at bottom of table.
+            caption: (str | List[str], optional): Caption displayed at bottom of table.
                 Only applies to "rich" tablefmt. Defaults to None.
             pager (bool, optional): Page Output / or not. Defaults to True.
             outfile (Path, optional): path/file of output file. Defaults to None.
@@ -497,6 +497,8 @@ class CLICommon:
             fold_cols (Union[List[str], str], optional): columns that will be folded (wrapped within the same column). Applies to tablfmt=rich. Defaults to [].
             cleaner (callable, optional): The Cleaner function to use.
         """
+        if isinstance(caption, list):
+            caption = "\n  ".join(caption)
         if resp is not None:
             resp = utils.listify(resp)
 

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2016,8 +2016,9 @@ def wlans(
 
     tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
     if group:  # Specifying the group implies verbose (same # of API calls either way.)
-        resp = central.request(central.get_full_wlan_list, group)
-        cli.display_results(resp, sort_by=sort_by, reverse=reverse, tablefmt=tablefmt, title=title, pager=pager, outfile=outfile, cleaner=cleaner.get_full_wlan_list, verbosity=verbose, format=tablefmt)
+        resp = central.request(central.get_full_wlan_list, group)  # TODO have get_full_wlan_list covert to list of dicts
+        caption = None  # if not resp else f"[green]{len(resp.output)}[/] SSIDs configured in group [cyan]{group}[/]"  # It's a str need JSON.loads...
+        cli.display_results(resp, title=title, caption=caption, pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, tablefmt=tablefmt, cleaner=cleaner.get_full_wlan_list, verbosity=verbose, format=tablefmt)
     elif verbose:
         import json
         group_res = central.request(central.get_groups_properties)
@@ -2047,7 +2048,11 @@ def wlans(
         cli.display_results(resp, sort_by=sort_by, reverse=reverse, tablefmt=tablefmt, title=title, pager=pager, outfile=outfile, cleaner=cleaner.get_full_wlan_list, verbosity=verbose, format=tablefmt)
     else:
         resp = central.request(central.get_wlans, **params)
-        cli.display_results(resp, sort_by=sort_by, reverse=reverse, tablefmt=tablefmt, title=title, pager=pager, outfile=outfile, cleaner=cleaner.get_wlans)
+        caption = None
+        if resp:
+            caption = [f'[green]{len(resp.output)}[/] SSIDs,  [green]{sum([wlan.get("client_count", 0) for wlan in resp.output])}[/] Wireless Clients.']
+            caption += ["Summary Output, Specify the group ([cyan]--group GROUP[/])",  "or use the verbose flag ([cyan]`-v`[/]) for additional details"]
+        cli.display_results(resp, tablefmt=tablefmt, title=title, caption=caption, pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, cleaner=cleaner.get_wlans)
 
 
 @app.command()

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -1159,12 +1159,18 @@ def dhcp(
 
 @app.command(short_help="Show firmware upgrade status")
 def upgrade(
-    device: List[str] = typer.Argument(..., metavar=iden_meta.dev, hidden=False, autocompletion=cli.cache.dev_completion),
+    device: List[str] = typer.Argument(
+        ...,
+        metavar=iden_meta.dev,
+        hidden=False,
+        autocompletion=cli.cache.dev_completion,
+        show_default=False,
+    ),
     do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
     do_table: bool = typer.Option(False, "--table", help="Output in table format",),
-    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
     default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,),

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2147,12 +2147,6 @@ def clients(
     sort_by: SortClientOptions = typer.Option(None, "--sort", show_default=False, rich_help_panel="Formatting",),
     reverse: bool = typer.Option(False, "-r", help="Reverse output order", show_default=False, rich_help_panel="Formatting",),
     verbose: bool = typer.Option(False, "-v", help="additional details (vertically)", show_default=False, rich_help_panel="Formatting",),
-    verbose2: bool = typer.Option(
-        False,
-        "-vv",
-        help="Show raw response (no formatting but still honors --yaml, --csv ... if provided)",
-        show_default=False,
-    ),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output",),
     default: bool = typer.Option(
         False, "-d",
@@ -2265,7 +2259,7 @@ def clients(
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
 
     verbose_kwargs = {}
-    if not verbose2 and not denylisted:
+    if not denylisted:
         verbose_kwargs["cleaner"] = cleaner.get_clients
         verbose_kwargs["cache"] = cli.cache
         verbose_kwargs["verbose"] = verbose

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -990,8 +990,9 @@ def poe(
     caption = "  Power values are in watts."
     if resp:
         resp.output = utils.listify(resp.output)  # if they specify an interface output will be a single dict.
-        _delivering_count = len(list(filter(lambda i: i.get("poe_detection_status", 99) == 3, resp.output)))
-        caption = f"{caption}  Interfaces delivering power: [bright_green]{_delivering_count}[/]"
+        if not port:
+            _delivering_count = len(list(filter(lambda i: i.get("poe_detection_status", 99) == 3, resp.output)))
+            caption = f"{caption}  Interfaces delivering power: [bright_green]{_delivering_count}[/]"
         if "poe_slots" in resp.output[0] and resp.output[0]["poe_slots"]:  # CX has the key but it appears to always be an empty dict
             caption = f"{caption}\n  Switch Poe Capabilities (watts): Max: [cyan]{resp.output[0]['poe_slots'].get('maximum_power_in_watts', '?')}[/]"
             caption = f"{caption}, Draw: [cyan]{resp.output[0]['poe_slots'].get('power_drawn_in_watts', '?')}[/]"
@@ -1577,7 +1578,7 @@ def lldp(
     Valid on APs and CX switches
 
     Use [cyan]cencli show aps -n --site <SITE>[/] to see lldp neighbors for all APs in a site.
-    NOTE: AOS-SW will return LLDP neighbors, but only it reports neighbors for connected Aruba devices managed in Central
+    NOTE: AOS-SW will return LLDP neighbors, but only reports neighbors for connected Aruba devices managed in Central
     """
     central = cli.central
 
@@ -1902,6 +1903,7 @@ def token(
 
 
 # TODO clean up output ... single line output
+# TODO restrict to GWs appears to only work on GW
 @app.command(short_help="Show device routing table")
 def routes(
     device: List[str] = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, show_default=False,),

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2286,7 +2286,7 @@ def clients(
         **verbose_kwargs
     )
 
-# TODO Sortby Enum
+
 @app.command()
 def tunnels(
     gateway: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_gw_completion, case_sensitive=False, show_default=False,),

--- a/centralcli/clishowaudit.py
+++ b/centralcli/clishowaudit.py
@@ -46,12 +46,13 @@ def show_logs_cencli_callback(ctx: typer.Context, cencli: bool):
     return cencli
 
 
+# TODO remove verbose2 using --raw now
 @app.command(
     help="Show Audit Logs. Audit Logs will displays prior 5 days if no time options are provided.",
     short_help="Show Audit Logs (last 5 days default)",
 )
 def logs(
-    args: List[str] = typer.Argument(
+    log_id: str = typer.Argument(
         None,
         metavar='[LOG_ID]',
         help="Show details for a specific log_id",
@@ -111,13 +112,13 @@ def logs(
         autocompletion=cli.cache.account_completion,
     ),
 ) -> None:
-    if cencli or (args and args[-1] == "cencli"):
+    if cencli or (log_id and log_id[-1] == "cencli"):
         from centralcli import log
         log.print_file() if not tail else log.follow()
         raise typer.Exit(0)
 
-    if args:
-        log_id = cli.cache.get_log_identifier(args[-1])
+    if log_id:
+        log_id = cli.cache.get_log_identifier(log_id)
     else:
         log_id = None
         if device:

--- a/centralcli/clishowospf.py
+++ b/centralcli/clishowospf.py
@@ -57,7 +57,7 @@ def neighbors(
     dev = cli.cache.get_dev_identifier(device)
     resp = central.request(central.get_ospf_neighbor, dev.serial)
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
-    cf = "[reset][italic dark_olive_green2]"
+    # cf = "[reset][italic dark_olive_green2]"
     caption = ""
 
     if resp.raw.get("summary"):
@@ -67,23 +67,20 @@ def neighbors(
             raise typer.Exit(0)
         else:
             caption = [
-                f'{cf} Router ID:[/] {summary["router_id"]} | {cf}OSPF Neigbors:[/] {summary["neighbor_count"]} | {cf}OSPF Interfaces:[/] {summary["interface_count"]}',
-                f'{cf}OSPF Areas:[/] {summary["area_count"]} | {cf}active LSA:[/] {summary["active_lsa_count"]} | {cf}rexmt LSA:[/] {summary["rexmt_lsa_count"]}'
+                f'[cyan]Router ID[/]: {summary["router_id"]} | [cyan]OSPF Neigbors[/]: {summary["neighbor_count"]} | [cyan]OSPF Interfaces[/]: {summary["interface_count"]}',
+                f'[cyan]OSPF Areas[/]: {summary["area_count"]} | [cyan]active LSA[/]: {summary["active_lsa_count"]} | [cyan]rexmt LSA[/]: {summary["rexmt_lsa_count"]}'
             ]
-            caption = "\n   ".join(caption)
 
-    title = f"{dev.name} OSPF Neighbors"
-
-    cli.display_results(\
+    cli.display_results(
         resp,
         tablefmt=tablefmt,
-        title=title,
+        title=f"{dev.name} OSPF Neighbors",
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,
         reverse=reverse,
         cleaner=cleaner.get_ospf_neighbor if not verbose else None,
-        caption=f"{caption}\n"
+        caption=caption
     )
 
 
@@ -120,33 +117,29 @@ def interfaces(
     dev = cli.cache.get_dev_identifier(device)
     resp = central.request(central.get_ospf_interface, dev.serial)
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
-    cf = "[reset][italic dark_olive_green2]"
+    # cf = "[reset][italic dark_olive_green2]"
     caption = ""
 
     if resp.raw.get("summary"):
         summary = resp.raw["summary"]
         if summary["admin_status"] is False:
-            print(f"OSPF is not enabled on {dev.name}")
-            raise typer.Exit(0)
+            cli.exit(f"OSPF is not enabled on {dev.name}", code=0)
         else:
             caption = [
-                f'{cf} Router ID:[/] {summary["router_id"]} | {cf}OSPF Neigbors:[/] {summary["neighbor_count"]} | {cf}OSPF Interfaces:[/] {summary["interface_count"]}',
-                f'{cf}OSPF Areas:[/] {summary["area_count"]} | {cf}active LSA:[/] {summary["active_lsa_count"]} | {cf}rexmt LSA:[/] {summary["rexmt_lsa_count"]}'
+                f'[cyan]Router ID[/]: {summary["router_id"]} | [cyan]OSPF Neigbors[/]: {summary["neighbor_count"]} | [cyan]OSPF Interfaces[/]: {summary["interface_count"]}',
+                f'[cyan]OSPF Areas[/]: {summary["area_count"]} | [cyan]active LSA[/]: {summary["active_lsa_count"]} | [cyan]rexmt LSA[/]: {summary["rexmt_lsa_count"]}'
             ]
-            caption = "\n   ".join(caption)
-
-    title = f"{dev.name} OSPF Interfaces"
 
     cli.display_results(
         resp,
         tablefmt=tablefmt,
-        title=title,
+        title=f"{dev.name} OSPF Interfaces",
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,
         reverse=reverse,
         cleaner=cleaner.get_ospf_interface if not verbose else None,
-        caption=f"{caption}\n",
+        caption=caption,
         full_cols=["ip/mask", "DR IP", "BDR IP", "DR rtr id", "BDR rtr id"]
     )
 
@@ -182,33 +175,29 @@ def area(
     dev = cli.cache.get_dev_identifier(device)
     resp = central.request(central.get_ospf_area, dev.serial)
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
-    cf = "[reset][italic dark_olive_green2]"
+    # cf = "[reset][italic dark_olive_green2]"
     caption = ""
 
     if resp.raw.get("summary"):
         summary = resp.raw["summary"]
         if summary["admin_status"] is False:
-            print(f"OSPF is not enabled on {dev.name}")
-            raise typer.Exit(0)
+            cli.exit(f"OSPF is not enabled on {dev.name}", code=0)
         else:
             caption = [
-                f'{cf} Router ID:[/] {summary["router_id"]} | {cf}OSPF Neigbors:[/] {summary["neighbor_count"]} | {cf}OSPF Interfaces:[/] {summary["interface_count"]}',
-                f'{cf}OSPF Areas:[/] {summary["area_count"]} | {cf}active LSA:[/] {summary["active_lsa_count"]} | {cf}rexmt LSA:[/] {summary["rexmt_lsa_count"]}'
+                f'[cyan]Router ID[/]: {summary["router_id"]} | [cyan]OSPF Neigbors[/]: {summary["neighbor_count"]} | [cyan]OSPF Interfaces[/]: {summary["interface_count"]}',
+                f'[cyan]OSPF Areas[/]: {summary["area_count"]} | [cyan]active LSA[/]: {summary["active_lsa_count"]} | [cyan]rexmt LSA[/]: {summary["rexmt_lsa_count"]}'
             ]
-            caption = "\n   ".join(caption)
-
-    title = f"{dev.name} OSPF Area Details"
 
     cli.display_results(
         resp,
         tablefmt=tablefmt,
-        title=title,
+        title=f"{dev.name} OSPF Area Details",
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,
         reverse=reverse,
         cleaner=cleaner.get_ospf_neighbor if not verbose else None,  # ospf_neighbor cleaner is sufficient here
-        caption=f"{caption}\n",
+        caption=caption,
         full_cols=["ip/mask", "DR IP", "BDR IP", "DR rtr id", "BDR rtr id"]
     )
 
@@ -244,8 +233,9 @@ def database(
     dev = cli.cache.get_dev_identifier(device)
     resp = central.request(central.get_ospf_database, dev.serial)
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="yaml")
-    cf = "[reset][italic dark_olive_green2]"
+    # cf = "[reset][italic dark_olive_green2]"
     caption = ""
+    pad = "  " if tablefmt == "yaml" else ""
 
     if resp.raw.get("summary"):
         summary = resp.raw["summary"]
@@ -254,23 +244,20 @@ def database(
             raise typer.Exit(0)
         else:
             caption = [
-                f'{cf} Router ID:[/] {summary["router_id"]} | {cf}OSPF Neigbors:[/] {summary["neighbor_count"]} | {cf}OSPF Interfaces:[/] {summary["interface_count"]}',
-                f'{cf}OSPF Areas:[/] {summary["area_count"]} | {cf}active LSA:[/] {summary["active_lsa_count"]} | {cf}rexmt LSA:[/] {summary["rexmt_lsa_count"]}'
+                f'[cyan]{pad}Router ID[/]: {summary["router_id"]} | [cyan]OSPF Neigbors[/]: {summary["neighbor_count"]} | [cyan]OSPF Interfaces[/]: {summary["interface_count"]}',
+                f'[cyan]OSPF Areas[/]: {summary["area_count"]} | [cyan]active LSA[/]: {summary["active_lsa_count"]} | [cyan]rexmt LSA[/]: {summary["rexmt_lsa_count"]}'
             ]
-            caption = "\n   ".join(caption)
-
-    title = f"{dev.name} OSPF Database Details"
 
     cli.display_results(
         resp,
         tablefmt=tablefmt,
-        title=title,
+        title=f"{dev.name} OSPF Database Details",
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,
         reverse=reverse,
         cleaner=cleaner.get_ospf_neighbor if not verbose else None,  # ospf_neighbor cleaner is sufficient here
-        caption=f"{caption}\n",
+        caption=caption,
         full_cols=["ip/mask", "DR IP", "BDR IP", "DR rtr id", "BDR rtr id"]
     )
 

--- a/centralcli/cliupgrade.py
+++ b/centralcli/cliupgrade.py
@@ -34,8 +34,9 @@ app = typer.Typer()
 def device(
     device: str = typer.Argument(
         ...,
-        metavar=iden.dev, show_default=False,
+        metavar=iden.dev,
         autocompletion=cli.cache.dev_completion,
+        show_default=False,
     ),
     version: str = typer.Argument(
         None,
@@ -90,6 +91,7 @@ def group(
         metavar=iden.group,
         help="Upgrade devices by group",
         autocompletion=cli.cache.group_completion,
+        show_default=False,
     ),
     version: str = typer.Argument(
         None,
@@ -108,8 +110,8 @@ def group(
         show_default=False,
         formats=["%m/%d/%Y %H:%M", "%d %H:%M"],
         ),
-    dev_type: AllDevTypes = typer.Option(..., help="Upgrade a specific device type",),
-    model: str = typer.Option(None, help="[applies to switches only] Upgrade a specific switch model"),
+    dev_type: AllDevTypes = typer.Option(..., help="Upgrade a specific device type", show_default=False,),
+    model: str = typer.Option(None, help="[applies to switches only] Upgrade a specific switch model", show_default=False,),
     reboot: bool = typer.Option(False, "-R", help="Automatically reboot device after firmware download (APs will reboot regardless)"),
     yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
     debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Additional Debug Logging",),

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -188,6 +188,7 @@ STRIP_KEYS = [
     "lsas",
     "commands",
     "stacks",
+    "routes",
 ]
 
 

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -426,8 +426,8 @@ def output(
                                 formatters.Terminal256Formatter(style='solarized-dark')
                                 )
 
-    if isinstance(raw_data, str):  # HACK
-        raw_data = raw_data.replace('✅', 'True').replace('❌', 'False')   #  TODO handle this better messes up column spacing if replacing string.
+    if isinstance(raw_data, str):  # HACK replace first pass is to line up cols but if table is tighter second pass will swap them regardless
+        raw_data = raw_data.replace('✅  ', 'True').replace('❌   ', 'False').replace('✅', 'True').replace('❌', 'False')   #  TODO handle this better
 
     return Output(rawdata=raw_data, prettydata=table_data, config=config)
 

--- a/centralcli/strings.py
+++ b/centralcli/strings.py
@@ -251,20 +251,6 @@ name\nphl-access\nsan-dc-tor\ncom-branches
 {common_add_delete_end}
 """
 
-clibatch_delete_devices_help = """
-[bright_green]Perform batch Delete operations using import data from file.[/]
-
-[cyan]cencli delete sites <IMPORT_FILE>[/] and
-[cyan]cencli delte groups <IMPORT_FILE>[/]
-    Do what you'd expect.
-
-[cyan]cencli batch delete devices <IMPORT_FILE>[/]
-
-    Delete devices will remove any subscriptions/licenses from the device and disassociate the device with the Aruba Central app in GreenLake.  It will then remove the device from the monitoring views, along with the historical data for the device.
-
-    Note: devices can only be removed from monitoring views if they are in a down state.  This command will delay/wait for any Up devices to go Down after the subscriptions/assignment to Central is removed, but it can also be ran again.  It will pick up where it left off, skipping any steps that have already been performed.
-"""
-
 _site_common = """
 [cyan]Provide geo-loc or address details, (Google Maps "Plus Codes" are supported) not both.
 Can provide both in subsequent calls, but api does not allow both in same call.[reset]
@@ -401,7 +387,6 @@ class ImportExamples:
 
 class LongHelp:
     def __init__(self):
-        self.batch_delete_devices = do_capture(clibatch_delete_devices_help)
         self.update_site = do_capture(cliupdate_site_help)
         self.add_site = do_capture(cliadd_site_help)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.2.3"
+version = "5.3.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.2.2"
+version = "5.2.3"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
💬 Add caption with counts to `show wlans`
💬 Improve the way formatting is done when using unicode characters to represent True/False, along with stripping them for file output
✨ 🐛 Add support for pagination for `/api/routing/...` endpoints.  They use a different paging mechanism than everything else.
      - `/api/routing/` endpoints use `marker` rather than `offset` where the `marker` is provided in the response if there are additional pages.  (This mechanism means the calls cant be sent async).
🧑‍💻 display_output `caption` will now accept a list of str.
⏪ revert marker --> offset argument change
💬 Improve caption formatting
💬 maintain spacing when removing unicode for output to file