### PR TITLE
:bookmark: v5.4.0

### DIFF
--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -348,10 +348,8 @@ class CentralApi(Session):
         stack_id: str = None,
         cluster_id: str = None,
         band: str = None,
-        # sort_by: str = None,
         offset: int = 0,
         limit: int = 1000,
-        # **kwargs,
     ) -> Response:
         """Get All clients
 
@@ -369,7 +367,6 @@ class CentralApi(Session):
             stack_id (str, optional): Return clients connected to stack with provided id. Defaults to None.
             cluster_id (str, optional): Return clients connected to cluster with provided id. Defaults to None.
             band (str, optional): Return (WLAN) clients connected to provided band. Defaults to None.
-            FIXME sort_by (str, optional): Sort Output on provided key field. Defaults to None.
             offset (int, optional): API offset. Defaults to 0.
             limit (int, optional): API record limit. Defaults to 1000, Max 1000.
 
@@ -383,8 +380,6 @@ class CentralApi(Session):
             "site": site,
             "serial": serial,
             "cluster_id": cluster_id,
-            # 'fields': fields,
-            # 'sort_by': sort_by,
             "offset": offset,
             "limit": limit,
             "calculate_total": True
@@ -403,6 +398,7 @@ class CentralApi(Session):
             self.BatchRequest(self.get_wireless_clients, **{**params, **wlan_only_params}),
             self.BatchRequest(self.get_wired_clients, **{**params, **wired_only_params})
         ]
+
         # FIXME if wireless clients call passes but wired fails there is no indication in cencli show clients output
         resp = await self._batch_request(reqs)
         if len(resp) == 2:  # and all(x.ok for x in resp):
@@ -417,9 +413,10 @@ class CentralApi(Session):
             resp = resp[1] if resp[1].ok else resp[0]
             resp.output = out
             resp.raw = raw
+            return resp
             # TODO need Response to have an attribute that stores failed calls so cli commands can display output of passed calls and details on errors (when some calls fail)
 
-        return resp
+        return resp[-1]
 
     async def get_client_roaming_history(
         self,

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -189,7 +189,7 @@ vlan_modes = {
 _short_value = {
     "Aruba, a Hewlett Packard Enterprise Company": "HPE/Aruba",
     "No Authentication": "open",
-    "last_connection_time": _time_diff_words,
+    "last_connection_time": lambda x: DateTime(x, "timediff"),  # _time_diff_words,
     "uptime": lambda x: DateTime(x, "durwords-short"),
     "updated_at": lambda x: DateTime(x, "mdyt"),
     "last_modified": _convert_epoch,

--- a/centralcli/cli.py
+++ b/centralcli/cli.py
@@ -966,7 +966,9 @@ def callback(
     update_cache: bool = typer.Option(False, "-U", hidden=True, lazy=True, callback=all_commands_callback),
 ) -> None:
     """
-    Aruba Central API CLI
+    Aruba Central API CLI.  A CLI for interacting with Aruba Central APIs.
+
+    Use [cyan]--raw[/] which is supported globally, to see the raw unformatted response from Aruba Central.
     """
     pass
 

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -509,11 +509,13 @@ class CLICommon:
                 log.error(f"Exception when trying to determine last rate-limit str for caption {e.__class__.__name__}")
 
             caption = caption or ""
-            if log.caption:  # TODO change caption to list of Tuples or dict or objects with loglevel so we can determine if :warning: should be prepended.  Or do it in the log
+            if log.caption:  # rich table is printed with emoji=False need to manually swap the emoji
+                # TODO see if table has option to only do emoji in caption
+                _log_caption = log.caption if log.caption.count(":") < 2 else log.caption.replace(":warning:", "\u26a0").replace(":information:", "\u2139")
                 if len(resp) > 1 and ":warning:" in log.caption:
-                    caption = f'{caption}\n[bright_red]  !!! Partial command failure !!!\n{log.caption}[/]'
+                    caption = f'{caption}\n[bright_red]  !!! Partial command failure !!!\n{_log_caption}[/]'
                 else:
-                    caption = f'{caption}\n{log.caption}'
+                    caption = f'{caption}\n{_log_caption}'
 
 
             for idx, r in enumerate(resp):

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -37,7 +37,7 @@ except (ImportError, ModuleNotFoundError) as e:
 from centralcli.constants import (
     SortInventoryOptions, ShowInventoryArgs, StatusOptions, SortWlanOptions, IdenMetaVars, CacheArgs, SortSiteOptions, SortGroupOptions, SortStackOptions, DevTypes, SortDevOptions,
     SortTemplateOptions, SortClientOptions, SortCertOptions, SortVlanOptions, SortSubscriptionOptions, SortRouteOptions, DhcpArgs, EventDevTypeArgs, ShowHookProxyArgs, SubscriptionArgs,
-    AlertTypes, SortAlertOptions, AlertSeverity, SortWebHookOptions, TunnelTimeRange, GenericDevTypes, lib_to_api, what_to_pretty, LIB_DEV_TYPE  # noqa
+    AlertTypes, SortAlertOptions, AlertSeverity, SortWebHookOptions, TunnelTimeRange, GenericDevTypes, ClientTimeRange, lib_to_api, what_to_pretty, lib_to_gen_plural, LIB_DEV_TYPE  # noqa
 )
 from centralcli.cache import CentralObject
 
@@ -2126,7 +2126,7 @@ def vsx(
 # FIXME show clients wireless <tab completion> does not filter based on type of device
 # FIXME show clients wireless AP-NAME does not filter only devices on that AP
 # Same applies for wired
-@app.command(help="Show clients/details")
+@app.command()
 def clients(
     client: str = typer.Argument(
         None,
@@ -2135,6 +2135,7 @@ def clients(
         autocompletion=cli.cache.client_completion,
         show_default=False,
     ),
+    past: ClientTimeRange = typer.Option(None, help="Collect Logs for past <past>, h=hours, d=days, w=weeks, m=months Valid Values: 3h, 1d, 1w, 1m, 3m [grey42]\[default: 3h][/]", show_default=False,),
     group: str = typer.Option(None, metavar="<Group>", help="Filter by Group", autocompletion=cli.cache.group_completion, show_default=False,),
     site: str = typer.Option(None, metavar="<Site>", help="Filter by Site", autocompletion=cli.cache.site_completion, show_default=False,),
     label: str = typer.Option(None, metavar="<Label>", help="Filter by Label", show_default=False,),
@@ -2142,7 +2143,8 @@ def clients(
     wired: bool = typer.Option(False, "-W", "--wired", help="Show only wired clients", show_default=False,),
     ssid: str = typer.Option(None, help="Filter by SSID [grey42 italic](Applies only to wireless clients)[/]", show_default=False,),
     denylisted: bool = typer.Option(False, "-D", "--denylisted", help="Show denylisted clients [grey42 italic](--dev must also be supplied)[/]",),
-    device: str = typer.Option(None, "--dev", metavar=iden_meta.dev, help="Filter by Device", autocompletion=cli.cache.dev_client_completion, show_default=False,),
+    failed: bool = typer.Option(False, "-F", "--failed", help="Show clients that have failed to connect", show_choices=False,),
+    device: str = typer.Option(None, "--dev", metavar=iden_meta.dev_many, help="Filter by Device(s)", autocompletion=cli.cache.dev_client_completion, show_default=False,),
     do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON", show_default=False, rich_help_panel="Formatting",),
     do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML", show_default=False, rich_help_panel="Formatting",),
     do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV", show_default=False, rich_help_panel="Formatting",),
@@ -2151,8 +2153,8 @@ def clients(
     update_cache: bool = typer.Option(False, "-U", hidden=True,),  # Force Update of cli.cache for testing
     sort_by: SortClientOptions = typer.Option(None, "--sort", show_default=False, rich_help_panel="Formatting",),
     reverse: bool = typer.Option(False, "-r", help="Reverse output order", show_default=False, rich_help_panel="Formatting",),
-    verbose: bool = typer.Option(False, "-v", help="additional details (vertically)", show_default=False, rich_help_panel="Formatting",),
-    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output",),
+    verbose: int = typer.Option(0, "-v", count=True, help="additional details (vertically)", show_default=False, rich_help_panel="Formatting",),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output", rich_help_panel="Common Options",),
     default: bool = typer.Option(
         False, "-d",
         is_flag=True,
@@ -2176,11 +2178,11 @@ def clients(
         rich_help_panel="Common Options",
     ),
 ) -> None:
+    """Show clients/details
+
+    Shows clients that have connected within the last 3 hours by default.
+    """
     central = cli.central
-    # device = utils.listify(device) if device else []
-    # device = device if not _dev else [*device, *_dev]
-    # TODO test --device and potentially restore multi-dev support
-    device = device or []
 
     kwargs = {}
     dev = None
@@ -2190,16 +2192,33 @@ def clients(
         _client = cli.cache.get_client_identifier(client, exit_on_fail=True)
         kwargs["mac"] = _client.mac
         title = f"Details for client [cyan]{_client.name}[/]|[cyan]{_client.mac}[/]|[cyan]{_client.ip}[/]"
-        verbose = True
+        verbose = verbose or 1
     elif device:
-        dev = cli.cache.get_dev_identifier(device)
-        kwargs["serial"] = dev.serial
-        title = f"{dev.name} Clients"
+        dev: CentralObject = cli.cache.get_dev_identifier(device)
+        args += ("wireless",) if dev.type == "ap" else ("wired",)
+        if dev.generic_type == "switch":
+            if dev.swack_id:
+                kwargs["stack_id"] = dev.swack_id
+        else:
+            kwargs["serial"] = dev.serial
+        title = f'{dev.name} Clients'
+        ignored = {
+            "group": group,
+            "site": site,
+            "label": label
+        }
+        if any([ignored.values()]):
+            for k, v in ignored.items():
+                if v:
+                    log.warning(f"[cyan]--{k}[/] [green]{v}[/] ignored.  Doesn't make sense with [cyan]--dev[/] [green]{dev.name}[/] specified.", log=False, caption=True)
+            group = site = label = None
+
 
     if denylisted:
         if not dev:
-            print(":warning:  [cyan]--device[/] is required when [cyan]-D|--denylisted[/] flag is set.")
-            raise typer.Exit(1)
+            cli.exit(":warning:  [cyan]--device[/] is required when [cyan]-D|--denylisted[/] flag is set.")
+        elif dev.type != "ap":
+            cli.exit(f"[cyan]--denylisted[/] flag is only valid for APs not {lib_to_gen_plural(dev.type)}.")
         else:
             args = (dev.serial,)
             title = f"{dev.name} Denylisted Clients"
@@ -2234,6 +2253,14 @@ def clients(
             else:
                 title = f"{title} (WLAN client filtered by those connected to [cyan]{ssid}[/])" if title.lower() == "all clients" else f"{title} connected to [cyan]{ssid}[/]"
 
+        if failed:
+            kwargs["client_status"] = "FAILED_TO_CONNECT"
+            title = title.replace("Clients", "Failed Clients")
+
+        if past:
+            kwargs["past"] = past.upper()
+            title = f'{title} (past {past.replace("h", " hours").replace("d", " days").replace("w", " weeks").replace("m", " months")})'
+
     if not denylisted:
         resp = central.request(cli.cache.update_client_db, *args, **kwargs)
     else:
@@ -2247,13 +2274,9 @@ def clients(
     _last_mac_text = ""
     if not client and not denylisted:
         if wired:
-            _count_text = f"{len(resp)} Wired Clients."
-            if resp.raw.get("last_client_mac"):
-                _count_text = f'{_count_text} [bright_green]Last Wired Mac[/]: [cyan]{resp.raw["last_client_mac"]}[/]'
+            _count_text = f"[cyan]{len(resp)}[/] Wired Clients."
         elif wireless:
-            _count_text = f"{len(resp)} Wireless Clients."
-            if resp.raw.get("last_client_mac"):
-                _count_text = f'{_count_text} [bright_green]Last Wireless Mac[/]: [cyan]{resp.raw["last_client_mac"]}[/]'
+            _count_text = f"[cyan]{len(resp)}[/] Wireless Clients."
         else:
             _tot = len(resp)
             wlan_raw = list(filter(lambda d: "raw_wireless_response" in d, resp.raw))
@@ -2262,11 +2285,8 @@ def clients(
             for _type, data in zip(["wireless", "wired"], [wlan_raw, wired_raw]):
                 caption_data[_type] = {
                     "count": "" if not data or "total" not in data[0][f"raw_{_type}_response"] else data[0][f"raw_{_type}_response"]["total"],
-                    "last_client_mac": "" if not data or "last_client_mac" not in data[0][f"raw_{_type}_response"] else data[0][f"raw_{_type}_response"]["last_client_mac"]
                 }
             _count_text = f"[reset]Counts: [bright_green]Total[/]: [cyan]{_tot}[/], [bright_green]Wired[/]: [cyan]{caption_data['wired']['count']}[/], [bright_green]Wireless[/]: [cyan]{caption_data['wireless']['count']}[/]"
-            _last_mac_text = f"[bright_green]Last Wired Mac[/]: [cyan]{caption_data['wired']['last_client_mac']}[/], [bright_green]Last Wireless Mac[/]: [cyan]{caption_data['wireless']['last_client_mac']}[/]"
-
 
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
 
@@ -2274,7 +2294,8 @@ def clients(
     if not denylisted:
         verbose_kwargs["cleaner"] = cleaner.get_clients
         verbose_kwargs["cache"] = cli.cache
-        verbose_kwargs["verbose"] = verbose
+        verbose_kwargs["verbosity"] = int(verbose)
+        verbose_kwargs["format"] = tablefmt
 
         # filter output on multiple devices
         # TODO maybe restore multi-device looks like was handled in filter
@@ -2283,16 +2304,14 @@ def clients(
 
     if sort_by:
         sort_by = "802.11" if sort_by == "dot11" else sort_by.value.replace("_", " ")
-        print(reverse)
         if sort_by == "last connected":  # We invert so the most recent client is on top
             reverse = not reverse
-        print(reverse)
 
     cli.display_results(
         resp,
         tablefmt=tablefmt,
         title=title,
-        caption=f"{_count_text} Use [cyan]-v[/] for more details, [cyan]--raw[/] for unformatted response.\n  {_last_mac_text}".rstrip() if not verbose and not denylisted else None,
+        caption=f"{_count_text} Use [cyan]-v[/] for more details, [cyan]--raw[/] for unformatted response." if not verbose and not denylisted else None,
         pager=pager,
         outfile=outfile,
         sort_by=sort_by,
@@ -2355,7 +2374,7 @@ def tunnels(
 
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="yaml")
 
-    cli.display_results(resp, title=f'{dev.rich_help_text} Tunnels', caption=caption, tablefmt=tablefmt, pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, cleaner=None)
+    cli.display_results(resp, title=f'{dev.rich_help_text} Tunnels', caption=caption, tablefmt=tablefmt, pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, cleaner=cleaner.get_gw_tunnels)
 
 
 

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -192,31 +192,12 @@ STRIP_KEYS = [
 ]
 
 
-CLIENT_STRIP_KEYS_VERBOSE = ["group_id", "label_id", "swarm_id"]
-CLIENT_STRIP_KEYS = [
-    *CLIENT_STRIP_KEYS_VERBOSE,
-    "interface_mac",
-    "labels",
-    "phy_type",
-    "radio_mac",
-    "radio_number",
-    "ht_type",
-    "maxspeed",
-    "speed",
-    "signal_db",
-    "signal_strength",
-    "encryption_method",
-    "usage",
-    "manufacturer",
-    "health",
-    "signal_strength"
-    "channel",
-    "os_type",
-    "band",
-    "snr",
-    "username",
-    "client_type",
-    ]
+class ClientTimeRange(str, Enum):  # = Literal["3h", "1d", "1w", "1m", "3m"]
+    _3h = "3h"
+    _1d = "1d"
+    _1w = "1w"
+    _1m = "1m"
+    _3m = "3m"
 
 
 class ShowArgs(str, Enum):
@@ -527,6 +508,7 @@ APIMethodType = Literal[
     "inventory"
 ]
 
+ClientStatus = Literal["FAILED_TO_CONNECT", "CONNECTED"]
 
 class LibToAPI:
     """Convert device type stored in Cache to type required by the different API methods

--- a/centralcli/logger.py
+++ b/centralcli/logger.py
@@ -139,8 +139,9 @@ class MyLogger:
         self.show = value
         self.setLevel(logging.DEBUG if value else logging.INFO)
 
-    def debug(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-
+    # If caption=True we assume log=False unless you specify log=True, default it to log, no caption.
+    def debug(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='debug', *args, **kwargs)
 
     def debugv(self, msgs: Union[list, str], log: bool = True, show: bool = None, *args, **kwargs) -> None:
@@ -150,28 +151,28 @@ class MyLogger:
         if self.DEBUG and self.verbose:
             self.log_print(msgs, log=log, show=show, level='debug', *args, **kwargs)
 
-    def info(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def info(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, *args, **kwargs)
 
-    def warning(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def warning(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='warning', *args, **kwargs)
 
-    def error(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def error(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='error', *args, **kwargs)
 
-    def exception(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def exception(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='exception', *args, **kwargs)
 
-    def critical(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def critical(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='critical', *args, **kwargs)
 
-    def fatal(self, msgs: Union[list, str], log: bool = True, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
-        # show = show or self.show
+    def fatal(self, msgs: Union[list, str], log: bool = None, show: bool = None, caption: bool = False, *args, **kwargs) -> None:
+        log = log if log is not None else not caption
         self.log_print(msgs, log=log, show=show, caption=caption, level='fatal', *args, **kwargs)
 
     def setLevel(self, level):

--- a/centralcli/objects.py
+++ b/centralcli/objects.py
@@ -97,25 +97,25 @@ class DateTime():
         return self.pretty
 
     def __bool__(self):
-        return self.epoch and self.epoch > 0
+        return bool(self.epoch and self.epoch > 0)
 
     def __len__(self) -> int:
         return len(self.epoch)
 
     def __lt__(self, other) -> bool:
-        return self.epoch < other
+        return True if self.epoch is None else bool(self.epoch < other)
 
     def __le__(self, other) -> bool:
-        return self.epoch <= other
+        return False if self.epoch is None else bool(self.epoch <= other)
 
     def __eq__(self, other) -> bool:
-        return self.epoch == other
+        return False if self.epoch is None else bool(self.epoch == other)
 
     def __gt__(self, other) -> bool:
-        return self.epoch > other
+        return False if self.epoch is None else bool(self.epoch > other)
 
     def __ge__(self, other) -> bool:
-        return self.epoch >= other
+        return False if self.epoch is None else bool(self.epoch >= other)
 
 
 class Encoder(JSONEncoder):

--- a/centralcli/objects.py
+++ b/centralcli/objects.py
@@ -4,20 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 from json import JSONEncoder
-from enum import Enum
 import pendulum
 from pathlib import Path
 
 
 TimeFormat = Literal["day-datetime", "durwords", "durwords-short", "timediff", "mdyt", "log"]
 
-# class TimeFormat(str, Enum):
-#     day_datetime = "day-datetime"
-#     durwords = "durwords"
-#     durwords_short = "durwords-short"
-#     timediff = "timediff"
-#     mydt = "mydt"
-#     log = "log"
 
 def _convert_epoch(epoch: float) -> str:
     """Thu, May 7, 2020 3:49 AM"""

--- a/centralcli/render.py
+++ b/centralcli/render.py
@@ -299,7 +299,7 @@ def rich_output(
         if account or caption:
             table.caption_justify = 'left'
             table.caption = '' if not account else f'[italic dark_olive_green2] Account: {account}[/]'
-            table.caption = table.caption if not caption else f"{table.caption}  {caption.lstrip()}"
+            table.caption = table.caption if not caption else f"{table.caption} {caption.lstrip()}"
 
         data_header = f"--\n{'Customer ID:':15}{customer_id}\n{'Customer Name:':15} {customer_name}\n--\n"
 

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -803,3 +803,29 @@ class Utils:
             return [f"{prefix}/{p}" for p in range(int(_start.split("/")[-1]), int(_end.split("/")[-1]) + 1)]
 
         return [iface for port in interfaces for p in port.split(",") for iface in expand_range(p)]
+
+    @staticmethod
+    def convert_bytes_to_human(size: int | float | Dict[str, int | float] | None, precision: int = 2, throughput: bool = False, speed: bool = False,) -> str | None:
+        if size is None:
+            return size
+
+        def _number_to_human(_size: int | float, precision: int = precision, throughput: bool = throughput, speed: bool = speed) -> str:
+            factor = 1000 if throughput or speed else 1024
+            suffixes=['B','KB','MB','GB','TB', 'PB'] if not speed else ["Mbps", "Gbps", "Tbps", "Pbps", "err", "err"]
+            suffix_idx = 0
+            while _size > factor and suffix_idx < 4:
+                suffix_idx += 1  # increment the index of the suffix
+                _size = _size/float(factor)  # apply the division
+
+            out = f"{round(_size, precision):.2f}"
+            out = out if not int(out.split(".")[-1]) == 0 else out.split(".")[0]
+
+            return f"{out} {suffixes[suffix_idx]}"
+
+        if isinstance(size, (int, float)):
+            return _number_to_human(size)
+
+        if isinstance(size, dict) and all([isinstance(v, (int, float)) for v in size.values()]):
+            return {k: _number_to_human(v) for k, v in size.items()}
+        else:
+            return size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.3.0"
+version = "5.4.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
- :sparkles: Overhaul `cencli show clients` Now supports more filtering options.
  -  :sparkles: Extensive improvements to verbose output format
  - :sparkles: proper sorting on last_connected field
  -   :sparkles: throughput/usage converted to human readable
   - :sparkles: `cencli show tunnels` gets cleaner which makes date fields and data usage/throughput fields human readable
- :label: Add sort Enum for Client Time Range, and Literal type for ClientStatus
- :technologist: Change default for log methods, when caption=True, it will not log to file unless log=True.  By default caption is False and it will log to file.
- :coffin: Remove unused code
- :technologist: Add helper to convert int/float output representing data bytes to human readable
- :speech_balloon: Handle emoji in log.caption
- :sparkles: Add support for additional filters to client methods
- :sparkles: Add support for filtering client output by SSID
- :speech_balloon: Minor caption formatting change
- :recycle: Break sort logic out into it's own method
- :speech_balloon: Improve help text
- :sparkles: Make `last connected` properly sortable in client output
- :bug: Fix return type if process stop due to failed initial call