### PR TITLE
🔖 v5.4.1

### DIFF
--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -664,8 +664,7 @@ def batch_add_devices(import_file: Path = None, data: dict = None, yes: bool = F
     if import_file is not None:
         data = config.get_file_data(import_file)
     elif not data:
-        print("[red]Error!![/] No import file provided")
-        raise typer.Exit(1)
+        cli.exit("No import file provided")
 
     if "devices" in data:
         data = data["devices"]
@@ -1167,8 +1166,7 @@ def batch_delete_devices(data: list | dict, *, ui_only: bool = False, cop_inv_on
     cache_devs: List[CentralObject | None] = [cli.cache.get_dev_identifier(d, silent=True, include_inventory=True, exit_on_fail=False) for d in serials_in]  # returns None if device not found in cache after update
     if len(serials_in) != len(cache_devs):
         log.warning(f"DEV NOTE: Error len(serials_in) ({len(serials_in)}) != len(cache_devs) ({len(cache_devs)})", show=True)
-    else:
-        log.warning(f"DEV NOTE: Error len(serials_in) ({len(serials_in)}) != len(cache_devs) ({len(cache_devs)})", show=True)
+
     not_in_inventory: List[str] = [d for d, c in zip(serials_in, cache_devs) if c is None]
     cache_devs: List[CentralObject] = [c for c in cache_devs if c]
     _all_in_inventory: Dict[str, Document] = cli.cache.inventory_by_serial

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2196,9 +2196,8 @@ def clients(
     elif device:
         dev: CentralObject = cli.cache.get_dev_identifier(device)
         args += ("wireless",) if dev.type == "ap" else ("wired",)
-        if dev.generic_type == "switch":
-            if dev.swack_id:
-                kwargs["stack_id"] = dev.swack_id
+        if dev.generic_type == "switch" and dev.swack_id:
+            kwargs["stack_id"] = dev.swack_id
         else:
             kwargs["serial"] = dev.serial
         title = f'{dev.name} Clients'
@@ -2282,11 +2281,14 @@ def clients(
             wlan_raw = list(filter(lambda d: "raw_wireless_response" in d, resp.raw))
             wired_raw = list(filter(lambda d: "raw_wired_response" in d, resp.raw))
             caption_data = {}
-            for _type, data in zip(["wireless", "wired"], [wlan_raw, wired_raw]):
-                caption_data[_type] = {
-                    "count": "" if not data or "total" not in data[0][f"raw_{_type}_response"] else data[0][f"raw_{_type}_response"]["total"],
-                }
-            _count_text = f"[reset]Counts: [bright_green]Total[/]: [cyan]{_tot}[/], [bright_green]Wired[/]: [cyan]{caption_data['wired']['count']}[/], [bright_green]Wireless[/]: [cyan]{caption_data['wireless']['count']}[/]"
+            if not device:
+                for _type, data in zip(["wireless", "wired"], [wlan_raw, wired_raw]):
+                    caption_data[_type] = {
+                        "count": "" if not data or "total" not in data[0][f"raw_{_type}_response"] else data[0][f"raw_{_type}_response"]["total"],
+                    }
+                _count_text = f"[reset]Counts: [bright_green]Total[/]: [cyan]{_tot}[/], [bright_green]Wired[/]: [cyan]{caption_data['wired']['count']}[/], [bright_green]Wireless[/]: [cyan]{caption_data['wireless']['count']}[/]"
+            else:
+                _count_text = f"[reset][bright_green]Client Count[/]: [cyan]{_tot}[/],"
 
     tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
 

--- a/centralcli/vscodeargs.py
+++ b/centralcli/vscodeargs.py
@@ -18,6 +18,10 @@ def vscode_arg_handler():
                         vsc_args = vsc_args.replace("cencli ", "")
                     # handle quoted args as single arg `"caas send-cmds \\'service dhcp\\' --device R3v SDBrA"`
                     vsc_args = vsc_args.replace('"', '\\"')  # vscode double escapes ' but not "
+                    # replace ~/ notation for home dir with full path
+                    if " ~/" in vsc_args:
+                        vsc_args = vsc_args.replace(" ~/", f" {Path.home()}/")
+
                     found = False
                     for qstr in ["\\'", '\\"']:
                         if qstr in vsc_args:  # I think this was for dev on Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "5.4.0"
+version = "5.4.1"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -50,7 +50,7 @@ def test_show_all_rich():
     if result.exception:
         traceback.print_exception(result.exception)
     assert result.exit_code == 0
-    assert "name" in result.stdout
+    assert "mac" in result.stdout
     assert "ip" in result.stdout
 
 


### PR DESCRIPTION
  - ✅ Update test to check for mac/ip tty size in test env is very small, name not guaranteed to display in output, "ip" and "mac" are full_length_cols, should always display
  - 🧑‍💻 vscode: detect `~/` and swap with full home path if provided as arg.
  - 🐛 fix scenario in `show clients` where `--dev` is provided and is a switch.  Was returning all wired c lients
  -  🐛 remove errant log from `batch delete`