### PR TITLE
 🔖 v6.0.2

### DIFF
--- a/centralcli/clishowbandwidth.py
+++ b/centralcli/clishowbandwidth.py
@@ -210,7 +210,7 @@ def client(
     device: str = typer.Option(None, "--dev", help="Show Bandwidth details for clients connected to a specific device", metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, case_sensitive=False, show_default=False,),
     group: str = typer.Option(None, help="Show Bandwidth for clients connected to devices in a specific group", metavar=iden_meta.group, autocompletion=cli.cache.group_completion, show_default=False),
     label: str = typer.Option(None, help="Show Bandwidth for clients connected to devices with a specific label", metavar=iden_meta.label, autocompletion=cli.cache.label_completion, show_default=False),
-    swarm_or_stack: bool = typer.Option(False, "-s", "--swarm", "--stack", help="Show Bandwidth for the swarm or stack the provided device belongs to [cyan]--dev[/] argument must be provided.[/]", show_default=False),
+    swarm_or_stack: bool = typer.Option(False, "-s", "--swarm", "--stack", help="Show Bandwidth for the swarm or stack the provided device belongs to [cyan]--dev[/] argument must be provided.", show_default=False),
     start: datetime = typer.Option(
         None,
         "-s", "--start",

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from sphinx.application import Sphinx
+
+from rich.traceback import install
+install(show_locals=True)
+
+docs_directory = Path(__file__).parent
+configuration_directory = docs_directory
+source_directory = docs_directory
+build_directory = docs_directory / '_build'
+doctree_directory = build_directory / '.doctrees'
+builder = 'html'
+
+app = Sphinx(srcdir=source_directory, confdir=configuration_directory, outdir=build_directory, doctreedir=doctree_directory, buildername=builder)
+app.build()

--- a/docs/centralcli.rst
+++ b/docs/centralcli.rst
@@ -49,6 +49,14 @@ centralcli.constants module
    :undoc-members:
    :show-inheritance:
 
+centralcli.objects module
+---------------------------
+
+.. automodule:: centralcli.objects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 centralcli.exceptions module
 ----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "6.0.1"
+version = "6.0.2"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
  - 🐛 resolve documentation build failure (unmatched markup closing tag in help text of `show bandwidth clients`)