### PR TITLE
:bookmark: v6.1.1

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -1971,7 +1971,7 @@ class Cache:
             "ap": "all_ap",
             "aps": "all_ap"
         }
-
+        dev_type = dev_type or "all"  # if they pass in None = "all"
         dev_type = lib_to_api_dev_type.get(dev_type, dev_type)
         if config.is_cop and dev_type == "gateway":
             dev_type = "controller"
@@ -2371,6 +2371,8 @@ class Cache:
                 db_res += [await update_funcs[0](**kwargs)]
                 if not db_res[-1]:
                     log.error(f"Cache Update aborting remaining {len(update_funcs)} cache updates due to failure in {update_funcs[0].__name__}", show=True, caption=True)
+                    if len(update_funcs) > 1:
+                        db_res += [Response(error=f"{f.__name__} aborted due to failure in previous cache update call ({update_funcs[0].__name__})") for f in update_funcs[1:]]
                 else:
                     if len(update_funcs) > 1:
                         db_res = [*db_res, *await asyncio.gather(*[f() for f in update_funcs[1:]])]

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1139,7 +1139,7 @@ class CentralApi(Session):
 
         Args:
             sku_type (str, optional): all/iap/switch/controller/gateway/vgw/cap/boc/all_ap/all_controller/others
-                Defaults to all.
+                Defaults to all, Passing in None = all.
             offset (int, optional): offset or page number Defaults to 0.
             limit (int, optional): Number of devices to get Defaults to 1000.
 
@@ -1147,6 +1147,7 @@ class CentralApi(Session):
             Response: CentralAPI Response object
         """
         url = "/platform/device_inventory/v1/devices"
+        sku_type = sku_type or "all"
 
         params = {
             'sku_type': sku_type,

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -796,8 +796,12 @@ class Session():
                     break
 
         # No errors but the total provided by Central doesn't match the # of records
-        if not failures and "total" in r.raw and isinstance(r.output, list) and len(r.output) < r.raw["total"]:
-            log.warning(f"Total records {len(r.output)} != the expected total {r.raw['total']} provided by central", show=True, caption=True)
+        try:
+            if not failures and isinstance(r.raw, dict)  and "total" in r.raw and isinstance(r.output, list) and len(r.output) < r.raw["total"]:
+                log.warning(f"Total records {len(r.output)} != the expected total {r.raw['total']} provided by central", show=True, caption=True)
+        except Exception:
+            ...  # r.raw could be bool for some POST endpoints
+
         return r
 
     # TODO verif here but token_data can not be empty, should not be optional.  Only optional in refresh_token

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -1079,6 +1079,7 @@ class CombinedResponse(Response):
 
         elapsed = 0
         raw = {}
+        output = []
         for idx, r in enumerate(_passed):
             this_output = r.output.copy()
             this_raw = r.raw.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "6.1.0"
+version = "6.1.1"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
  - :bug: prevent potential reference before assignment if all calls Failed in response.CombinedResp.flatten_resp
  - :bug: return expected number of Response objects in _check_fresh even if aborting after 1st update fails.
  - Make dev_type None equiv to dev_type="all" (in call to fetch inventory)
  - :loud_sound: Put try/except around log message verifying total and count add up
  - :bug: fix flaw in logic impacting CoP delete in `batch delete devices`