### PR TITLE
:bookmark: v6.3.0

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2351,16 +2351,16 @@ class Cache:
         ):
         update_funcs, db_res = [], []
         dev_update_funcs = ["update_inv_db", "update_dev_db"]
-        if inv_db:
-            update_funcs += [self.update_inv_db]
+        if group_db:
+            update_funcs += [self.update_group_db]
         if dev_db:
             update_funcs += [self.update_dev_db]
+        if inv_db:
+            update_funcs += [self.update_inv_db]
         if site_db:
             update_funcs += [self.update_site_db]
         if template_db:
             update_funcs += [self.update_template_db]
-        if group_db:
-            update_funcs += [self.update_group_db]
         if label_db:
             update_funcs += [self.update_label_db]
         if license_db:
@@ -2410,16 +2410,17 @@ class Cache:
     ) -> List[Response]:
         db_res = None
         db_map = {
+            "group_db": group_db,
             "dev_db": dev_db,
             "inv_db": inv_db,
             "site_db": site_db,
             "template_db": template_db,
-            "group_db": group_db,
             "label_db": label_db,
             "license_db": license_db
         }
         update_count = list(db_map.values()).count(True)
-        refresh = refresh or bool(update_count)
+        refresh = refresh or bool(update_count)  # if any DBs are set to update they will update regardless of refresh value
+        update_all = True if not update_count else False  # if all are False default is to update all DBs but only if refresh=True
 
         if refresh or not config.cache_file.is_file() or not config.cache_file.stat().st_size > 0:
             _word = "Refreshing" if update_count else "Populating"
@@ -2433,7 +2434,7 @@ class Cache:
             log.info(f"Cache Refreshed {update_count if update_count != len(db_map) else 'all'} tables in {elapsed}s")
 
             if failed:
-                res_map = ", ".join(db for idx, (db, do_update) in enumerate(db_map.items()) if do_update and not db_res[idx].ok)
+                res_map = ", ".join(db for idx, (db, do_update) in enumerate(db_map.items()) if do_update or update_all and not db_res[idx].ok)
                 err_msg = f"Cache refresh returned an error updating ({res_map})"
                 log.error(err_msg)
                 self.central.spinner.fail(err_msg)

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -573,7 +573,7 @@ class Cache:
         out = []
 
         if not args:  # HACK click 8.x work-around now pinned at click 7.2 until resolved
-            args = [v for k, v in ctx.params.items() if v and k in ["serial", "mac", "group"]]
+            args = [item for k, v in ctx.params.items() if v for item in [k, v]]  # TODO ensure k is last item when v = incomplete
 
         if args[-1].lower() == "group":
             out = [m for m in self.group_completion(incomplete, args)]

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1073,12 +1073,14 @@ class CentralApi(Session):
         return resp
 
 
-    async def get_all_templates(self, groups: List[dict] = None, **params) -> Response:
+    async def get_all_templates(self, groups: List[dict] | List[str ]= None, **params) -> Response:
         """Get data for all defined templates from Aruba Central
 
         Args:
-            groups (List[dict], optional): List of group dictionaries (If provided additional API
+            groups (List[dict] | List[str], optional): List of groups.  If provided additional API
                 calls to get group names for all template groups are not performed).
+                If a list of str (group names) is provided all are queried for templates
+                If a list of dicts is provided:  It should look like: [{"name": "group_name", "template group": {"Wired": True, "Wireless": False}}]
                 Defaults to None.
 
         Returns:
@@ -1090,6 +1092,8 @@ class CentralApi(Session):
                 return resp
 
             template_groups = [g["group"] for g in resp.output if True in g["template_details"].values()]
+        elif isinstance(groups, list) and all([isinstance(g, str) for g in groups]):
+                template_groups = groups
         else:
             template_groups = [g["name"] for g in groups if True in g["template group"].values()]
 

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -2571,6 +2571,49 @@ class CentralApi(Session):
 
         return await self.get(url, params=params)
 
+    async def get_networks_bandwidth_usage(
+        self,
+        network: str,
+        group: str = None,
+        swarm_id: str = None,
+        label: str = None,
+        site: str = None,
+        from_time: int | float | datetime = None,
+        to_time: int | float | datetime = None,
+    ) -> Response:
+        """WLAN Network Bandwidth usage.
+
+        Use get_wlans to fetch list of networks.
+
+        Args:
+            network (str): Network name (ssid) to return usage for
+            group (str, optional): Filter by group name
+            swarm_id (str, optional): Filter by Swarm ID. Field supported for AP clients only
+            label (str, optional): Filter by Label name
+            site (str, optional): Filter by Site name
+            from_time (int | float | datetime, optional): Need information from this timestamp. Timestamp is epoch
+                in seconds. Default is current timestamp minus 3 hours
+            to_time (int | float | datetime, optional): Need information to this timestamp. Timestamp is epoch in
+                seconds. Default is current timestamp
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = "/monitoring/v2/networks/bandwidth_usage"
+        from_time, to_time = utils.parse_time_options(from_time, to_time)
+
+        params = {
+            'network': network,
+            'group': group,
+            'swarm_id': swarm_id,
+            'label': label,
+            'site': site,
+            'from_timestamp': from_time,
+            'to_timestamp': to_time
+        }
+
+        return await self.get(url, params=params)
+
     async def get_clients_bandwidth_usage(
         self,
         group: str = None,

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -1758,28 +1758,15 @@ def rename(
     if yes or typer.confirm("\nProceed with AP rename?", abort=True):
         resp = cli.central.batch_request(calls)
 
-    # elif lldp:
-    #     kwargs = {}
-    #     if group:
-    #         kwargs["group"] = cli.cache.get_group_identifier(group).name
-    #     if ap:
-    #         kwargs["serial"] = cli.cache.get_dev_identifier(ap, dev_type="ap").serial
-    #     if site:
-    #         kwargs["site"] = cli.cache.get_site_identifier(site).name
-    #     if model:
-    #         kwargs["model"] = model
-    #     if label:
-    #         kwargs["label"] = label
-
-    #     resp = do_lldp_rename(_lldp_rename_get_fstr(), default_only=default_only, lower=lower, space=space, **kwargs)
 
     cli.display_results(resp, tablefmt="action")
     # cache update
-    if import_file: # TODO have lldp return dict same as import file for reference during cache update
+    if import_file:
         for r in resp:
             if r.ok and r.status != 299:  # 299 is default, indicates no call was performed, this is returned when the current data matches what's already set for the dev
                 dev = cli.cache.get_dev_identifier(r.output)
                 dev.data["name"] = data[r.output]["hostname"]
+                # TODO upsert is very slow at scale, can grab cli.cache.devices_by_serial update then update_dev_db with data
                 cli.cache.DevDB.upsert(dev.data, cli.cache.Q.serial == dev.data["serial"])
 
 

--- a/centralcli/clidel.py
+++ b/centralcli/clidel.py
@@ -416,7 +416,7 @@ def device(
                 # if archive requests all pass we summarize the result.
                 if all([r.ok for r in batch_resp[0:2]]) and all([not r.get("failed_devices") for r in batch_resp[0:2]]):
                     batch_resp[0].output = batch_resp[0].output.get("message")
-                    batch_resp[1].output = f'  {batch_resp[1].output.get("message", "")}\n  Subscriptions successfully removed for {len(batch_resp[1].output.get("succeeded_devices"))} devices.\n  [italic]archive/unarchive flushes all subscriptions for a device.'
+                    batch_resp[1].output =  f'  {batch_resp[1].output.get("message", "")}\n  Subscriptions successfully removed for {len(batch_resp[1].output.get("succeeded_devices", []))} devices.\n  \u2139  archive/unarchive flushes all subscriptions for a device.'
                 else:
                     show_archive_results(batch_resp[0])  # archive
                     show_archive_results(batch_resp[1])  # unarchive

--- a/centralcli/clishowaudit.py
+++ b/centralcli/clishowaudit.py
@@ -9,17 +9,17 @@ import time
 import pendulum
 from pathlib import Path
 from rich import print
-from typing import List
+from datetime import datetime
 
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from centralcli import cleaner, cli, utils
+    from centralcli import cleaner, cli, utils, log
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from centralcli import cleaner, cli, utils
+        from centralcli import cleaner, cli, utils, log
     else:
         print(pkg_dir.parts)
         raise e
@@ -45,18 +45,50 @@ def show_logs_cencli_callback(ctx: typer.Context, cencli: bool):
 
     return cencli
 
+def _verify_time_range(start: datetime | pendulum.DateTime | None, end: datetime | pendulum.DateTime = None, past: str = None, show_all: bool = False, max_days: int = 90) -> pendulum.DateTime | None:
+    if show_all:
+        if any([start, end, past]):
+            cli.exit("Invalid combination of arguments. [cyan]--start[/], [cyan]--end[/], and [cyan]--past[/] are invalid when [cyan]--all[/] is used.")
 
-# TODO remove verbose2 using --raw now
-@app.command(
-    help="Show Audit Logs. Audit Logs will displays prior 5 days if no time options are provided.",
-    short_help="Show Audit Logs (last 5 days default)",
-)
-def logs(
+    if end and past:
+        log.warning("[cyan]--end[/] flag ignored, providing [cyan]--past[/] implies end is now.", caption=True,)
+        end = None
+
+    if start and past:
+        log.warning(f"[cyan]--start[/] flag ignored, providing [cyan]--past[/] implies end is now - {past}", caption=True,)
+
+    if past:
+        start = cli.past_to_start(past=past)
+
+    if start is None:
+        return start, end
+
+    if not hasattr(start, "timezone"):
+        start = pendulum.from_timestamp(start.timestamp(), tz="UTC")
+    if end is None:
+        _end = pendulum.now(tz=start.timezone)
+    else:
+        _end = end if hasattr(end, "timezone") else pendulum.from_timestamp(end.timestamp(), tz="UTC")
+
+    delta = _end - start
+
+    if delta.days > max_days:
+        if end:
+            cli.exit(f"[cyan]--start[/] and [cyan]--end[/] provided span {delta.days} days.  Max allowed is 90 days.")
+        else:
+            log.info(f"[cyan]--past[/] option spans {delta.days} days.  Max allowed is 90 days.  Output constrained to 90 days.", caption=True)
+            return cli.past_to_start("2_159h"), end  # 89 days and 23 hours to avoid issue with API endpoint
+
+    return start, _end
+
+
+@app.command()
+def system_logs(
     log_id: str = typer.Argument(
         None,
         metavar='[LOG_ID]',
         help="Show details for a specific log_id",
-        autocompletion=lambda incomplete: cli.cache.get_log_identifier(incomplete),
+        autocompletion=lambda incomplete: cli.cache.get_log_identifier(incomplete, include_cencli=False),
         show_default=False,
     ),
     tail: bool = typer.Option(False, "-f", help="follow tail on log file (implies show logs)", is_eager=True),
@@ -64,7 +96,7 @@ def logs(
     start: str = typer.Option(None, "-s", "--start", help="Start time of range to collect logs, format: yyyy-mm-ddThh:mm (24 hour notation)", show_default=False,),
     end: str = typer.Option(None, "-e", "--end", help="End time of range to collect logs, formnat: yyyy-mm-ddThh:mm (24 hour notation)", show_default=False,),
     past: str = typer.Option(None, "-p", "--past", help="Collect Logs for last <past>, d=days, h=hours, m=mins i.e.: 3h", show_default=False,),
-    _all: bool = typer.Option(False, "-a", "--all", help="Display all available audit logs.  Overrides default of 48h", show_default=False,),
+    _all: bool = typer.Option(False, "-a", "--all", help="Display all available audit logs.  Overrides default of 5 days", show_default=False,),
     device: str = typer.Option(
         None,
         metavar=iden_meta.dev,
@@ -89,7 +121,7 @@ def logs(
         show_default=False
     ),
     verbose: bool = typer.Option(False, "-v", help="Show logs with original field names and minimal formatting (vertically)"),
-    verbose2: bool = typer.Option(False, "-vv", help="Show raw unformatted response from Central API Gateway"),
+    raw: bool = typer.Option(False, "--raw", help="Show raw unformatted response from Central API Gateway"),
     pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
     outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
     update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
@@ -112,6 +144,18 @@ def logs(
         autocompletion=cli.cache.account_completion,
     ),
 ) -> None:
+    """Show Aruba Central audit logs
+
+    This command shows logs associated with Aruba Central itself.
+    i.e. [cyan]Device Onboarded[/]
+         [cyan]Device checked in[/]
+         [cyan]New API Gateway app added (token creation)[/]
+
+    Use [cyan]show audit logs[/] to show audit event logs.
+    or [cyan]show logs[/] to show device event logs.
+
+    :clock5:  Displays prior 5 days if no time options are provided.
+    """
     if cencli or (log_id and log_id[-1] == "cencli"):
         from centralcli import log
         log.print_file() if not tail else log.follow()
@@ -121,38 +165,39 @@ def logs(
         log_id = cli.cache.get_log_identifier(log_id)
     else:
         log_id = None
-        if device:
-            device = cli.cache.get_dev_identifier(device)
 
-        if _all and True in list(map(bool, [start, end, past])):
-            print("Invalid combination of arguments. [cyan]--start[/], [cyan]--end[/], and [cyan]--past[/]")
-            print("are invalid when [cyan]--all[/] is used.")
+    if device:
+        device = cli.cache.get_dev_identifier(device)
+
+    if _all and True in list(map(bool, [start, end, past])):
+        print("Invalid combination of arguments. [cyan]--start[/], [cyan]--end[/], and [cyan]--past[/]")
+        print("are invalid when [cyan]--all[/] is used.")
+        raise typer.Exit(1)
+
+    if start:
+        # TODO add common dt function allow HH:mm and assumer current day
+        try:
+            dt = pendulum.from_format(start, 'YYYY-MM-DDTHH:mm')
+            start = (dt.int_timestamp)
+        except Exception:
+            typer.secho(f"start appears to be invalid {start}", fg="red")
             raise typer.Exit(1)
-
-        if start:
-            # TODO add common dt function allow HH:mm and assumer current day
-            try:
-                dt = pendulum.from_format(start, 'YYYY-MM-DDTHH:mm')
-                start = (dt.int_timestamp)
-            except Exception:
-                typer.secho(f"start appears to be invalid {start}", fg="red")
-                raise typer.Exit(1)
-        if end:
-            try:
-                dt = pendulum.from_format(end, 'YYYY-MM-DDTHH:mm')
-                end = (dt.int_timestamp)
-            except Exception:
-                typer.secho(f"end appears to be invalid {start}", fg="red")
-                raise typer.Exit(1)
-        if past:
-            now = int(time.time())
-            past = past.lower().replace(" ", "")
-            if past.endswith("d"):
-                start = now - (int(past.rstrip("d")) * 86400)
-            if past.endswith("h"):
-                start = now - (int(past.rstrip("h")) * 3600)
-            if past.endswith("m"):
-                start = now - (int(past.rstrip("m")) * 60)
+    if end:
+        try:
+            dt = pendulum.from_format(end, 'YYYY-MM-DDTHH:mm')
+            end = (dt.int_timestamp)
+        except Exception:
+            typer.secho(f"end appears to be invalid {start}", fg="red")
+            raise typer.Exit(1)
+    if past:
+        now = int(time.time())
+        past = past.lower().replace(" ", "")
+        if past.endswith("d"):
+            start = now - (int(past.rstrip("d")) * 86400)
+        if past.endswith("h"):
+            start = now - (int(past.rstrip("h")) * 3600)
+        if past.endswith("m"):
+            start = now - (int(past.rstrip("m")) * 60)
 
     kwargs = {
         "log_id": log_id,
@@ -173,29 +218,157 @@ def logs(
     if kwargs.get("log_id"):
         cli.display_results(resp, tablefmt="action")
     else:
-        if verbose2:
-            tablefmt = "raw"
-        else:
-            tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
-        _cmd_txt = typer.style('show audit logs <id>', fg='bright_green')
+        tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
+
         cli.display_results(
             resp,
             tablefmt=tablefmt,
             title="Audit Logs",
             pager=pager,
             outfile=outfile,
-            # TODO move sort_by underscore removal to display_results
-            sort_by=sort_by if not sort_by else sort_by.replace("_", " "),  # has_details -> 'has details'
+            sort_by=sort_by,
             reverse=reverse,
             cleaner=cleaner.get_audit_logs if not verbose else None,
             cache_update_func=cli.cache.update_log_db if not verbose else None,
-            caption=f"[reset]Use {_cmd_txt} to see details for a log.  Logs lacking an id don\'t have details.",
+            caption="Use [cyan]show audit system-logs <id>[/] to see details for a log.  Logs lacking an id don't have details.",
+        )
+
+
+@app.command()
+def logs(
+    log_id: str = typer.Argument(
+        None,
+        metavar='[LOG_ID]',
+        help="Show details for a specific log (log_id from previous run of the command)",
+        autocompletion=lambda incomplete: cli.cache.get_log_identifier(incomplete, include_cencli=False),
+        show_default=False,
+    ),
+    group: str = typer.Option(None, "--group", help="Filter Audit event logs by group", show_default=False,),
+    # start: str = typer.Option(None, "-s", "--start", help="Start time of range to collect logs, format: yyyy-mm-ddThh:mm (24 hour notation)", show_default=False,),
+    # end: str = typer.Option(None, "-e", "--end", help="End time of range to collect logs, formnat: yyyy-mm-ddThh:mm (24 hour notation)", show_default=False,),
+    # past: str = typer.Option(None, "-p", "--past", help="Collect Logs for last <past>, d=days, h=hours, m=mins i.e.: 3h", show_default=False,),
+    start: datetime = typer.Option(
+        None,
+        "-s", "--start",
+        help="Start time of logs [grey42]\[default: 48 hours ago][/]",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%m/%d/%Y"],
+        show_default=False,
+    ),
+    end: datetime = typer.Option(
+        None,
+        "-e", "--end",
+        help="End time of logs [grey42]\[default: Now][/]",
+        formats=["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%m/%d/%Y"],
+        show_default=False,
+    ),
+    past: str = typer.Option(None, "-p", "--past", help="Collect bandwidth details for last <past>, w=weeks, d=days, h=hours, m=mins i.e.: 3h [grey42]\[default: 48h][/]", show_default=False,),
+    _all: bool = typer.Option(False, "-a", "--all", help="Display all available audit logs.  Overrides default of 48h", show_default=False,),
+    device: str = typer.Option(
+        None,
+        metavar=iden_meta.dev,
+        help="Filter logs by device",
+        autocompletion=cli.cache.dev_completion,
+        show_default=False,
+    ),
+    _class: str = typer.Option(None, "--class", help="Filter logs by classification (fuzzy match)", show_default=False,),
+    count: int = typer.Option(None, "-n", help="Collect Last n logs", show_default=False,),
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON"),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML"),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV"),
+    do_table: bool = typer.Option(False, "--table", help="Output in table format"),
+    sort_by: LogSortBy = typer.Option(None, "--sort", show_default=False,),  # Uses post formatting field headers
+    reverse: bool = typer.Option(
+        True, "-r",
+        help="Reverse Output order Default order: newest on bottom.",
+        show_default=False
+    ),
+    verbose: bool = typer.Option(False, "-v", help="Show logs with original field names and minimal formatting (vertically)"),
+    raw: bool = typer.Option(False, "--raw", help="Show raw unformatted response from Central API Gateway"),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output"),
+    outfile: Path = typer.Option(None, "--out", help="Output to file (and terminal)", writable=True, show_default=False,),
+    update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cli.cache for testing
+    default: bool = typer.Option(
+        False, "-d",
+        is_flag=True,
+        help="Use default central account",
+        show_default=False,
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        envvar="ARUBACLI_DEBUG",
+        help="Enable Additional Debug Logging",
+    ),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
+) -> None:
+    """Show Audit Event Logs.
+
+    Other available log commands:
+      - [cyan]show audit system-logs[/] to show audit logs related to Central itself.
+      - [cyan]show logs[/] to show device event logs.
+
+    :clock2:  Displays prior 2 days if no time options are provided.
+    """
+    title = "audit event logs"
+    start, end = _verify_time_range(start, end, past=past, show_all=_all)
+
+    if all(x is None for x in [start, end]):
+        start = pendulum.now(tz="UTC").subtract(days=2)
+        title = f"{title} for last 2 days"
+    elif _all:
+        title = f"All available {title}"
+
+    dev_id = None
+    if device:
+        dev = cli.cache.get_dev_identifier(device)
+        dev_id = dev.serial if not dev.type == "ap" else dev.swack_id  # AOS10 AP swack_id is serial
+        title = f"{title} related to {dev.summary_text}"
+        if group:
+            log.warning(f"[cyan]--group[/] [bright_green]{group}[/] ignored as it doesn't make sense with [cyan]--device[/] [bright_green]{device}[/]", caption=True)
+            group = None
+    elif group:
+        group = cli.cache.get_group_identifier(group)
+        title = f"{title} associated with group {group.name}"
+
+    kwargs = {
+        'log_id': None if not log_id else cli.cache.get_log_identifier(log_id),
+        'group_name': None if not group else group.name,
+        'device_id': dev_id,
+        'classification': _class,
+        'start_time': None if _all else start.int_timestamp,
+        'end_time': None if _all or end is None else end.int_timestamp,
+        'count': count,
+    }
+
+    resp = cli.central.request(cli.central.get_audit_logs_events, **kwargs)
+
+    if log_id is not None:
+        cli.display_results(resp, tablefmt="action")
+    else:
+        tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
+
+        cli.display_results(
+            resp,
+            tablefmt=tablefmt,
+            title=title,
+            pager=pager,
+            outfile=outfile,
+            sort_by=sort_by,
+            reverse=reverse,
+            cleaner=cleaner.get_audit_logs if not verbose else None,
+            cache_update_func=cli.cache.update_log_db if not verbose else None,
+            caption="Use [cyan]show audit logs <id>[/] to see details for a log.  Logs lacking an id don't have details.",
         )
 
 @app.callback()
 def callback():
     """
-    Show Aruba Central audit logs
+    Show Aruba Central audit logs / audit event logs
     """
     pass
 

--- a/centralcli/clitest.py
+++ b/centralcli/clitest.py
@@ -195,6 +195,51 @@ def method(
         typer.echo(f"\n{typer.style('Raw Response Output', fg='bright_green')}:")
         cli.display_results(data=resp.raw, tablefmt="json", pager=pager, outfile=outfile)
 
+
+@app.command(hidden=True,)
+def command(
+    yes: bool = typer.Option(False, "-Y", "-y", help="Bypass confirmation prompts - Assume Yes"),
+    do_json: bool = typer.Option(False, "--json", is_flag=True, help="Output in JSON", show_default=False),
+    do_yaml: bool = typer.Option(False, "--yaml", is_flag=True, help="Output in YAML", show_default=False),
+    do_csv: bool = typer.Option(False, "--csv", is_flag=True, help="Output in CSV", show_default=False),
+    do_table: bool = typer.Option(False, "--table", is_flag=True, help="Output in Table", show_default=False),
+    outfile: Path = typer.Option(None, help="Output to file (and terminal)", writable=True, show_default=False,),
+    pager: bool = typer.Option(False, "--pager", help="Enable Paged Output", show_default=False,),
+    update_cache: bool = typer.Option(False, "-U", hidden=True),  # Force Update of cache for testing
+    default: bool = typer.Option(False, "-d", is_flag=True, help="Use default central account", show_default=False,
+                                 callback=cli.default_callback),
+    debug: bool = typer.Option(False, "--debug", envvar="ARUBACLI_DEBUG", help="Enable Debug Logging",
+                               callback=cli.debug_callback),
+    debugv: bool = typer.Option(
+        False, "--debugv",
+        envvar="ARUBACLI_VERBOSE_DEBUG",
+        help="Enable verbose Debug Logging",
+        hidden=True,
+        callback=cli.verbose_debug_callback,
+    ),
+    account: str = typer.Option(
+        "central_info",
+        envvar="ARUBACLI_ACCOUNT",
+        help="The Aruba Central Account to use (must be defined in the config)",
+        autocompletion=cli.cache.account_completion,
+    ),
+) -> None:
+    """This is a hidden test message used for automated testing.
+
+    This command should not be used.
+
+    What this command does changes based on what needs to be tested at the time.
+    """
+    resp = Response()
+    from centralcli import render
+    resp.output = render.rich_capture('  Subscriptions successfully removed for devices.\n  :information:  archive/unarchive flushes all subscriptions for a device.', emoji=True)
+    # tablefmt = cli.get_format(
+    #     do_json, do_yaml, do_csv, do_table, default="rich"
+    # )
+
+    cli.display_results(resp, tablefmt="action")
+
+
 @app.callback()
 def callback():
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "6.2.0"
+version = "6.3.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "6.1.1"
+version = "6.2.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,7 +1,7 @@
 from typer.testing import CliRunner
 
 from cli import app  # type: ignore # NoQA
-from . import test_site_file, test_data
+from . import test_site_file, test_data, test_batch_device_file
 
 runner = CliRunner()
 
@@ -19,3 +19,16 @@ def test_batch_del_sites():
     assert result.exit_code == 0
     assert "success" in result.stdout
     assert result.stdout.count("success") == len(test_data["batch"]["sites"])
+
+def test_batch_add_devices():
+    result = runner.invoke(app, ["batch", "add",  "devices", f'{str(test_batch_device_file)}', "-Y"])
+    assert result.exit_code == 0
+    assert "success" in result.stdout.lower()
+    assert "200" in result.stdout  # /platform/device_inventory/v1/devices
+    assert "201" in result.stdout  # /configuration/v1/preassign
+
+def test_batch_del_devices():
+    result = runner.invoke(app, ["batch", "delete",  "devices", f'{str(test_batch_device_file)}', "-Y"])
+    assert result.exit_code == 0
+    assert "subscriptions successfully removed" in result.stdout.lower()
+    assert "200" in result.stdout


### PR DESCRIPTION
  - :sparkles: Add bandwidth usage for wlan/ssid `cencli show bandwidth wlan <wlan>`
  - :speech_balloon: Improve error msg / spinner when cache update has partial failure
  - :technologist: Allow List of group names for get_all_templates
  - :sparkles: allow friendly dev iden for `cencli assign license` (useful if you remvoe/re-add subscription)
  - :zap: improve smg_kw_completion
  - :coffin: clean up commented code from lldp refactor
  - :card_file_box: cache update after auto rename by LLDP
    - :recycle: do_lldp_rename is now get_lldp_names and returns dictionary
    - Actual calls are parsed by the same logic as if the data were pulled from an import file.  So gets same cache update treatment
    - :bug: Fix bug in lldp rename when using %h[1-4] (h could be anything valid) in format string.
  - :white_check_mark: Add tests for batch add/delete devices
  - :speech_balloon: improve spinner, output formatting