### PR TITLE
:bookmark: v7.2.3

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -1968,7 +1968,7 @@ class Cache:
                 if c.name.lower().startswith(incomplete.lower()):
                     out += [(c.name, c.help_text)]
                 elif c.mac.strip(":.-").lower().startswith(incomplete.strip(":.-")):
-                    out += [(c.mac.replace(":", "-"), c.help_text)]  # TODO completion behavior has changed.  This works-around issue bash doesn't complete past 00: and zsh treats each octet as a dev name when : is used.
+                    out += [(c.mac, c.help_text)]
                 elif c.ip.startswith(incomplete):
                     out += [(c.ip, c.help_text)]
                 else:
@@ -1976,7 +1976,7 @@ class Cache:
                     out += [(c.name, f'{c.help_text} FailSafe Match')]
 
         for c in out:
-            yield c
+            yield c[0].replace(":", "-"), c[1]  # TODO completion behavior has changed.  This works-around issue bash doesn't complete past 00: and zsh treats each octet as a dev name when : is used.
 
     def event_log_completion(
         self,

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -464,6 +464,10 @@ class CachePortal(CentralObject):
     def __rich__(self) -> str:
         return f'[bright_green]Portal Profile[/]:[bright_green]{self.name}[/]|[cyan]{self.id}[/]'
 
+    @property
+    def help_text(self):
+        return render.rich_capture(self.__rich__())
+
 
 class CacheTemplate(CentralObject):
     db: Table | None = None
@@ -1355,9 +1359,9 @@ class Cache:
             match = [m for m in match if m.name not in args]
             for m in sorted(match, key=lambda i: i.name):
                 if m.name.startswith(incomplete):
-                    out += [tuple([m.name, m.id])]
+                    out += [tuple([m.name, m.help_text])]
                 elif m.id.startswith(incomplete):
-                    out += [tuple([m.id, m.name])]
+                    out += [tuple([m.id, m.help_text])]
                 else:
                     out += [tuple([m.name, m.help_text])]  # failsafe, shouldn't hit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.2.2"
+version = "7.2.3"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -5,14 +5,14 @@ from . import test_site_file, test_group_file, test_data, test_batch_device_file
 import traceback
 from rich.traceback import Traceback
 from rich import print
-from centralcli import cache
+
 
 runner = CliRunner()
 
 def test_batch_add_groups():
     result = runner.invoke(app, ["batch", "add",  "groups", str(test_group_file), "-Y"])
     assert result.exit_code == 0
-    assert len([g for g in cache.groups_by_name.keys() if g.startswith("cencli_test_group")]) == len(test_data["batch"]["groups_by_name"])
+    assert result.stdout.lower().count("created") == len(test_data["batch"]["groups_by_name"])
 
 
 def test_batch_del_groups():


### PR DESCRIPTION
- :rewind: revert part of client completion change.  Needs to be here for empty `incomplete`, zsh doesn't like the colons.
- :sparkles: help_text for portal completion
- :white_check_mark: Change success test for batch add groups test