### PR TITLE
:bookmark: v7.2.4

### DIFF
--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1626,7 +1626,7 @@ def show_interfaces(data: List[dict] | dict, verbosity: int = 0, dev_type: DevTy
         key_order = verbosity_keys[verbosity]
         # send all key/value pairs through formatters
         data = [
-            dict(short_value(k, d.get(k),) for k in key_order) for d in data
+            dict(short_value(k, d[k],) for k in key_order if k in d) for d in data
         ]
     else:
         key_order = [*key_order, *data[-1].keys()]

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -383,8 +383,7 @@ class CLICommon:
         else:
             return default
 
-    @staticmethod
-    def write_file(outfile: Path, outdata: str) -> None:
+    def write_file(self, outfile: Path, outdata: str) -> None:
         """Output data to file
 
         Args:
@@ -407,19 +406,22 @@ class CLICommon:
 
             print(f"\n[cyan]Writing output to {outfile}... ", end="")
 
-            out_msg = None
-            try:
-                if isinstance(outdata, (dict, list)):
-                    outdata = json.dumps(outdata, indent=4)
-                outfile.write_text(outdata)  # typer.unstyle(outdata) also works
-            except Exception as e:
-                outfile.write_text(f"{outdata}")
-                out_msg = f"Error ({e.__class__.__name__}) occurred during attempt to output to file.  " \
-                    "Used simple string conversion"
+            if not outfile.parent.is_dir():
+                self.econsole.print(f"[red]Directory Not Found[/]\n[dark_orange3]:warning:[/]  Unable to write output to [cyan]{outfile.name}[/].\nDirectory [cyan]{str(outfile.parent.absolute())}[/] [red]does not exist[/].")
+            else:
+                out_msg = None
+                try:
+                    if isinstance(outdata, (dict, list)):
+                        outdata = json.dumps(outdata, indent=4)
+                    outfile.write_text(outdata)  # typer.unstyle(outdata) also works
+                except Exception as e:
+                    outfile.write_text(f"{outdata}")
+                    out_msg = f"Error ({e.__class__.__name__}) occurred during attempt to output to file.  " \
+                        "Used simple string conversion"
 
-            print("[italic green]Done")
-            if out_msg:
-                log.warning(out_msg, show=True)
+                print("[italic green]Done")
+                if out_msg:
+                    log.warning(out_msg, show=True)
 
     @staticmethod
     def exit(msg: str = None, code: int = 1, emoji: bool = True) -> None:

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2012,6 +2012,7 @@ def wlans(
         "calculate_client_count": True,
     }
 
+    # TODO specifying WLAN name ... is ignored if verbose
     tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
     if group:  # Specifying the group implies verbose (same # of API calls either way.)
         resp = central.request(central.get_full_wlan_list, group)
@@ -2035,7 +2036,7 @@ def wlans(
     else:
         resp = central.request(central.get_wlans, **params)
         caption = None
-        if resp:
+        if resp and not name:
             caption = [f'[green]{len(resp.output)}[/] SSIDs,  [green]{sum([wlan.get("client_count", 0) for wlan in resp.output])}[/] Wireless Clients.']
             caption += ["Summary Output, Specify the group ([cyan]--group GROUP[/])",  "or use the verbose flag ([cyan]`-v`[/]) for additional details"]
         cli.display_results(resp, tablefmt=tablefmt, title=title, caption=caption, pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, cleaner=cleaner.get_wlans)

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2879,7 +2879,7 @@ def portals(
 # TODO add sort_by completion, portal completion
 @app.command()
 def guests(
-    portal: str = typer.Argument(..., help="portal name", show_default=False,),
+    portal: str = typer.Argument(..., help="portal name", autocompletion=cli.cache.portal_completion, show_default=False,),
     sort_by: str = cli.options.sort_by,
     reverse: bool = cli.options.reverse,
     do_json: bool = cli.options.do_json,

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -166,7 +166,7 @@ def _build_device_caption(resp: Response, *, inventory: bool = False, dev_type: 
 
     # Put together counts caption string
     if status:
-        _cnt_str = ", ".join([f'[{"bright_green" if status.lower() == "up" else "red"}]{t}[/]: [cyan]{status_by_type[t]["total"]}[/]' for t in status_by_type])
+        _cnt_str = ", ".join([f'[{"bright_green" if status.lower() == "up" else "red"}]{status.capitalize()} {t if t != "ap" else "APs"}[/]: [cyan]{status_by_type[t]["total"]}[/]' for t in status_by_type])
     elif inventory:
         _cnt_str = f"Total in inventory: [cyan]{len(resp.output)}[/], "
         _cnt_str = _cnt_str + ", ".join(
@@ -561,7 +561,7 @@ def aps(
         if up and down:
             ...  # They used both flags.  ignore
         elif up or down:
-            status = "Down" if down else "Up"
+            status = "down" if down else "up"
 
         show_devices(
             aps, dev_type="ap", include_inventory=with_inv, verbosity=verbose, outfile=outfile, update_cache=update_cache, group=group, site=site, label=label, status=status,

--- a/centralcli/clitest.py
+++ b/centralcli/clitest.py
@@ -167,7 +167,7 @@ def method(
         resp = _check_bool_to_str(args, kwargs, resp_str=str(e))
 
     attrs = {
-        k: v for k, v in resp.__dict__.items() if k not in ["output", "raw"] and (log.DEBUG or not k.startswith("_"))
+        k: v for k, v in resp.__dict__.items() if k not in ["output", "raw", "data_key"] and (log.DEBUG or not k.startswith("_"))
     }
 
     req = (

--- a/centralcli/models.py
+++ b/centralcli/models.py
@@ -411,7 +411,7 @@ class Client(BaseModel):
     @classmethod
     def pretty_dt(cls, dt: datetime) -> DateTime:
         if dt is None:  # TODO all with potential for there not to be a value need this
-            return None
+            return DateTime(None, "timediff")  # resolves PydanticSerializationError when model_dump_json is called on client with None for last_connected (Failed)
 
         return DateTime(dt.timestamp(), "timediff")
 

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -383,7 +383,8 @@ class Response:
                 r = r.replace("message: ", "").replace(self.output["message"], f'[red italic]{self.output["message"]}[/]')
 
         r = r.replace("failed:", "[red]failed[/]:").replace("FAILED", "[red]FAILED[/red]").replace("failed_devices", "[red]failed_devices[/]").replace("INVALID", "[red]INVALID[/]")
-        r = r.replace("SUCCESS", "[bright_green]SUCCESS[/]").replace("Success", "[bright_green]Success[/]").replace("success", "[bright_green]success[/]").replace("succeeded_devices", "[bright_green]succeeded_devices[/]")
+        r = r.replace("SUCCESS", "[bright_green]SUCCESS[/]").replace("Success", "[bright_green]Success[/]").replace("Success[/]fully", "Successfully[/]")
+        r = r.replace("Success", "[bright_green]Success[/]").replace("success", "[bright_green]success[/]").replace("succeeded_devices", "[bright_green]succeeded_devices[/]")
         r = r.replace("invalid_device", "[red]invalid_device[/]").replace("blocked_device", "[red]blocked_device[/red]").replace("ATHENA_ERROR_DEVICE_ALREADY_EXIST", "[italic dark_orange3]Device already exists[/]")
 
         # sanitize sensitive data for demos

--- a/centralcli/strings.py
+++ b/centralcli/strings.py
@@ -589,3 +589,10 @@ class ImportExamples:
         if key not in self.__dict__.keys():
             log.error(f"An attempt was made to get {key} attr from ImportExamples which is not defined.")
             return f":warning: [bright_red]Error[/] no str defined for [cyan]ImportExamples.{key}[/]"
+
+cron_weekly = """#!/usr/bin/env bash
+
+/bin/su -c "{{py_path}} {{exec_path}} refresh token -d {{accounts}}" {{user}} &&
+    logger -t centralcli "Token Refreshed via cron" ||
+    logger -t centralcli "Token Refresh returned error"
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.2.3"
+version = "7.2.4"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
- :sparkles: Add `cencli show cron`
- :bug: fix issue where interface cleaner was stripping out speed on switches.
- :bug: fix bug when -R is specified
- :sparkles: verify individual client if cache indicates client is offline.  Better error msg when that occurs.
- :bug: resolve validation error in pydantic model with None for last_connected (failed client)
- :bug: fix potential double cache update when dev_type passed to get_dev_identifier
- :speech_balloon: Improve show <DEV TYPE> caption when --up / --down flag is used,.
- :sparkles: Add portal comletion for `show guests`
- :bug: fix exception building caption when wlan name is provided
- :art: improve colorized output
- :goal_net: catch and show error if --out directory does not exist.