### PR TITLE
🔖 v7.2.9

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2540,7 +2540,7 @@ class Cache:
             return batch_resp
 
         inv_resp, sub_resp = batch_resp  # if first call failed above if would result in return.
-        _inv_by_ser = {dev["serial"]: dev for dev in inv_resp.raw["devices"]}
+        _inv_by_ser = {} if not inv_resp.ok else {dev["serial"]: dev for dev in inv_resp.raw["devices"]}
 
         if not batch_resp[1].ok:
             log.error(f"Call to fetch subscription details failed.  {batch_resp[1].error}.  Subscription details provided from previously cached values.", caption=True)

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -265,8 +265,8 @@ class CacheInvDevice(CentralObject):
         self.model: str = data["model"]
         self.sku: str = data["sku"]
         self.services: str | None = data["services"]
-        self.subscription_key: str = data["subscription_key"]
-        self.subscription_expires: int | float = data["subscription_expires"]
+        self.subscription_key: str = data.get("subscription_key")
+        self.subscription_expires: int | float = data.get("subscription_expires")
 
     @classmethod
     def set_db(cls, db: Table):
@@ -1403,7 +1403,7 @@ class Cache:
                 yield m
 
         elif args and args[-1].lower() == "site":
-            out = [m for m in self.site_completion(incomplete, args)]
+            out = [m for m in self.site_completion(ctx, incomplete, args)]
             for m in out:
                 ##  This was required for completion to work in click 8.x when case doesn't match
                 ##  i.e. site: WadeLab incomplete: wade in click 7 completes wade -> WadeLab
@@ -2066,7 +2066,7 @@ class Cache:
 
         args = args or [item for k, v in ctx.params.items() if v for item in [k, v]]
 
-        match = self.get_site_identifier(
+        match: CacheSite = self.get_site_identifier(
             incomplete.replace('"', "").replace("'", ""),
             completion=True,
         )
@@ -2074,7 +2074,7 @@ class Cache:
         out = []
         if match:
             for m in sorted(match, key=lambda i: i.name):
-                match_attrs = [a for a in [m.name, m.id, m.address, m.city, m.state, m.zipcode] if a]
+                match_attrs = [a for a in [m.name, m.id, m.address, m.city, m.state, m.zip] if a]
                 if all([attr not in args for attr in match_attrs]):
                     matched_attribute = [attr for attr in match_attrs if str(attr).startswith(incomplete)]
                     # err_console.print(f"\n{match_attrs=}, {matched_attribute=}, {incomplete=}")  # DEBUG completion

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -6096,6 +6096,7 @@ class CentralApi(Session):
         return await self.get(url)
 
 
+    # API-FLAW none of the auto_subscribe endpoints work
     async def get_auto_subscribe(
         self,
     ) -> Response:

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1441,7 +1441,7 @@ def get_client_roaming_history(data: List[dict]) -> List[dict]:
 
     return data
 
-def get_fw_version_list(data: List[dict], format: TableFormat = "rich") -> List[dict]:
+def get_fw_version_list(data: List[dict], format: TableFormat = "rich", verbose: bool = False) -> List[dict]:
     # Override default behavior of k, v formatter (default which implies rich will use unicode check mark for beta)
     if format != "rich" and "release_status" in data[-1].keys():
         _short_value["release_status"] = lambda v: "True" if "beta" in v.lower() else "False"
@@ -1450,6 +1450,9 @@ def get_fw_version_list(data: List[dict], format: TableFormat = "rich") -> List[
         dict(short_value(k, d[k]) for k in d) for d in data
     ]
     data = strip_no_value(data)
+
+    if format == "rich" and not verbose and utils.tty:
+        data = data[0:utils.tty.rows - 12]
 
     return data
 

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -1238,8 +1238,8 @@ def unsubscribe(
         if cli.confirm(yes):
             resp = cli.central.batch_request(unsub_reqs)
 
-    if not dis_cen and all([r.ok for r in resp]):
-        inv_devs = [{**d, "services": None} for d in devices]
+    if not dis_cen:
+        inv_devs = [{**d, "services": None} for r, d in zip(resp, devices) if r.ok]
         cache_resp = cli.cache.InvDB.update_multiple([(dev, cli.cache.Q.serial == dev["serial"]) for dev in inv_devs])
         if len(inv_devs) != len(cache_resp):
             log.warning(

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -1235,7 +1235,7 @@ def unsubscribe(
 
         cli.display_results(data=devices, tablefmt="rich", title="Devices to be unsubscribed", caption=f'{len(devices)} devices will be Unsubscribed')
         print("[bright_green]All Devices Listed will have subscriptions unassigned.[/]")
-        if yes or typer.confirm("\nProceed?", abort=True):
+        if cli.confirm(yes):
             resp = cli.central.batch_request(unsub_reqs)
 
     if not dis_cen and all([r.ok for r in resp]):

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -358,7 +358,7 @@ def show_devices(
             _ = cli.central.request(cli.cache.refresh_inv_db, device_type=dev_type)
             resp = cli.cache.get_devices_with_inventory(no_refresh=True, dev_type=dev_type, status=status)
 
-        caption = None if not resp.ok else _build_device_caption(resp, inventory=include_inventory, dev_type=dev_type, status=status, verbosity=verbosity)
+        caption = None if not resp.ok or not resp.output else _build_device_caption(resp, inventory=include_inventory, dev_type=dev_type, status=status, verbosity=verbosity)
 
     tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default=default_tablefmt)
     title_sfx = [

--- a/centralcli/clishowfirmware.py
+++ b/centralcli/clishowfirmware.py
@@ -223,6 +223,7 @@ def _list(
     dev_type: DevTypes = typer.Option(None, help="Get firmware list for a device type", show_default=False,),
     swarm: bool = typer.Option(False, "--swarm", "-s", help="Get available firmware for IAP cluster associated with provided device", show_default=False,),
     swarm_id: str = typer.Option(None, help="Get available firmware for specified IAP cluster", show_default=False,),
+    verbose: int = cli.options.verbose,
     do_json: bool = cli.options.do_json,
     do_yaml: bool = cli.options.do_yaml,
     do_csv: bool = cli.options.do_csv,
@@ -236,6 +237,8 @@ def _list(
 ):
     """Show available firmware list for a specific device or a type of device
     """
+    caption = None if verbose else "\u2139  Showing a single screens worth of the most recent versions, to see full list use [cyan]-v[/] (verbose)"
+
     dev: CentralObject = device if not device else cli.cache.get_dev_identifier(device, conductor_only=True,)
 
     # API-FLAW # HACK API at least for AOS10 APs returns Invalid Value for device <serial>, convert to --dev-type
@@ -269,7 +272,9 @@ def _list(
 
 
     resp = cli.central.request(cli.central.get_firmware_version_list, **kwargs)
-    cli.display_results(resp, tablefmt=tablefmt, title=title, pager=pager, outfile=outfile, cleaner=cleaner.get_fw_version_list, format=tablefmt)
+    cli.display_results(
+        resp,
+        tablefmt=tablefmt, title=title, caption=caption, pager=pager, outfile=outfile, set_width_cols={"version": {"min": 25}}, cleaner=cleaner.get_fw_version_list, format=tablefmt, verbose=bool(verbose))
 
 
 @app.callback()

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -590,7 +590,7 @@ class Config:
                 print(f"[red]ignoring username {username}.")
                 password = None
             elif not username:
-                username = None
+                username = password = None
                 print()  # They did not enter a username.  CR is for correct format of config output
             else:
                 password = ask("password", password=True)
@@ -614,7 +614,8 @@ class Config:
             else:
                 config_data = f"{yaml.safe_dump(config_data)}{config_comments}"
                 Console().rule("\n\n[bold cyan]Resulting Configuration File Content")
-                print(config_data.replace(password, "*********"))
+                _config_data = config_data if not password else config_data.replace(password, "*********")
+                print(_config_data)
                 Console().rule()
                 if Confirm.ask("\nContinue?"):
                     print(f"\n\n[cyan]Writing to {self.file}")

--- a/centralcli/strings.py
+++ b/centralcli/strings.py
@@ -507,18 +507,18 @@ Requires the following keys (include as header row for csv import):
 
 # -- // UNSUBSCRIBE DEVICES \\ --
 data = """
-serial
-CN12345678
-CN12345679
-CN12345680
+serial,license
+CN12345678,foundation_switch_6300
+CN12345679,foundation_switch_6200
+CN12345680,advanced_switch_6300
 """
 example = Example(data, type="devices", action="other")
 clibatch_unsubscribe = f"""[italic cyan]cencli batch unsubscribe IMPORT_FILE[/]:
 
 Accepts the following keys (include as header row for csv import):
-    [cyan]serial[/]
+    [cyan]serial[/], [cyan]license[/]
 
-[italic]Other fields can be included, but only serial, is evaluated
+[italic]Other fields can be included, but only serial, and license are evaluated
 any subscriptions associated with the serial will be removed.
 
 {example}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.2.8"
+version = "7.2.9"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
 - 🐛Populate inventory cache with sub/expiration when cache is updated after device add
 - 🐛 Handle corner case where a comma was used in the group name.  Ignore it.
 - 🐛 Fix bug when password which is optional is not provided (regression when password in output was masked).
 - ⚡️ forgo caption/counts if no payload in `show <dev_type>`
 - 💬 Add `-v` option to show firmware list.  Show 1 screen worth of recent versions by default.
 - 🗃️ Update inv cache after batch unsubscribe even if partial failure
 - 🥅 handle failure in inventory API call