### PR TITLE
🔖 v7.3.1

### DIFF
--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -908,6 +908,8 @@ class Utils:
 
     @staticmethod
     def older_than(ts: int | float | datetime, time_frame: int, unit: Literal["days", "hours", "minutes", "seconds", "weeks", "months"] = "days", tz: str = "UTC") -> bool:
+        if str(ts).isdigit() and len(str(int(ts))) > 10:  # if ts in milliseconds convert to seconds
+            ts = ts / 1000
         dt = ts if isinstance(ts, datetime) else pendulum.from_timestamp(ts, tz=tz)
         diff = pendulum.now(tz=tz) - dt
         return getattr(diff, f'in_{unit}')() > time_frame

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.3.0"
+version = "7.3.1"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
 - 👽️ normalize ts milliseconds to seconds if necessary in `utils.older_than(...)`.  Seems to be necessary in python3.12 / pendulum 3.0 (behavior changed).  Impacted `show clients`