### PR TITLE
🔖 v7.3.2

### DIFF
--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 import sys
 from enum import Enum
 from typing import Literal, Union

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.3.1"
+version = "7.3.2"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
 - 🚑 fix crash related to missing __future__.annotations impacting python version prior to 3.10