### PR TITLE
🔖 v7.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A CLI app for interacting with Aruba Central Cloud Management Platform. With cro
 
 ![centralcli Animated Demo](https://raw.githubusercontent.com/Pack3tL0ss/central-api-cli/master/docs/img/cencli-demo.gif)
 
+## Known Issues
+When running with Python 3.12 it's possible to see a number of SyntaxWarning messages regarding "invaslid escape sequence".  This is due to a change in behavior in 3.12.  This will be resolved in an upcoming release.  The warnings do not impact functionality.
+
 ## Features
 
 - Cross Platform Support
@@ -51,8 +54,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 
 #### Install `centralcli` via `uv`
 ```bash
-# install centralcli (will also quickly install Python 3.12 if needed)
-uv tool install --python 3.12 centralcli
+# install centralcli (will also quickly install Python 3.11 if needed)
+uv tool install --python 3.11 centralcli
 ```
 
 Then to Upgrade `centralcli`

--- a/README.md
+++ b/README.md
@@ -28,34 +28,47 @@ A CLI app for interacting with Aruba Central Cloud Management Platform. With cro
 
 ## Installation
 
-Requires python 3.8+ and pip
-> Use `python3 -V` to determine version, but pip won't allow it to install if Python is not >= 3.8
+The recommended method is to use uv, which is a single Rust binary that you can use to install Python apps. It's significantly faster than alternative tools, and will get you up and running with Posting in seconds.  `uv` will install `centralcli` in an isolated environment and expose the `cencli` command in PATH.
 
-### simple
+You don't even need to worry about installing Python yourself - uv will manage everything for you.
 
-```shell
-# On Debian based system if pip is not a recognized command
-sudo apt install python3-pip
-
-# Install centralcli
-pip install centralcli
-
-# optional install speedups for centralcli (this pulls in additional optional dependencies, that can improve performance.)  Minimal impact in most scenarios.
-pip install centralcli[speedups]
+### uv
+#### Install `uv` on Linx/Mac:
+```bash
+# quick install on MacOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### ideal
-> It's ideal to install in a virtual environment (venv) on *nix based systems.  A virtualenv is an isolated environment.  This is prefered as it avoids any potential package conflicts with any system executables that use the system-wide python.  When installing in a venv some steps have to be taken to ensure the venv is in PATH so `cencli` is a recognized command, and tab completion is retained.  The venv either needs to be activated or the venv/bin directory needs to be added to PATH for completion to work.  If this is something foriegn to you, you can install pipx which is like pip but installs packages in virtual environments and automatically takes care of the rest.
+#### Install `uv` on Windows:
+```bash
+# quick install on Windows via PowerShell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+> Changing the execution policy allows running a script from the internet.
 
-**Option 1 via pipx:**
+`uv` can also be installed via Homebrew, Cargo, Winget, pipx, and more. See the [installation guide](https://docs.astral.sh/uv/getting-started/installation/) for more information.
+
+
+#### Install `centralcli` via `uv`
+```bash
+# install centralcli (will also quickly install Python 3.12 if needed)
+uv tool install --python 3.12 centralcli
+```
+
+Then to Upgrade `centralcli`
+```bash
+uv tool upgrade centralcli
+```
+
+### pipx
+`centralcli` can also be installed via pipx, similar to `uv` pipx will install `centralcli` in an isolated environment, and expose the `cencli` command in PATH.
 
 > The first section below is for Debian based systems refer to [pipx documentation](https://pipx.pypa.io/stable/installation/) for instructions on other OSs.
-  ```shell
+  ```bash
   # install pipx (Debian)
   sudo apt update
   sudo apt install pipx
   pipx ensurepath
-  sudo pipx ensurepath --global  # optional refer to pipx docs
 
   # install central CLI
   pipx install centralcli --include-deps
@@ -64,16 +77,19 @@ pip install centralcli[speedups]
   pipx install centralcli[speedups] --force  # force if centralcli was already installed and you are just adding speedups
   ```
 
-**Option 2 manual installation in a venv:**
+Then to Upgrade `centralcli`
+```bash
+pip upgrade centralcli
+```
+
+### pip (manually install in virtual environment)
 
 > The example below is for Debian based systems, where `apt` is referenced but should be easy to translate to other OSs given you have some familiarity with the package management commands (i.e. `dnf`).  On Windows python should install with pip.  The pip commands are still valid.
   ```shell
   # (Debian) If you don't have pip
   sudo apt update
   sudo apt install python3-pip
-
-  # Install virtualenv
-  python3 -m pip install virtualenv                 # Alternatively on Debian based systems: 'sudo apt install python3-virtualenv'
+  sudo apt install python3-virtualenv
 
   # create a directory to store the venv in
   cd ~                                              # ensure you are in your home dir
@@ -97,14 +113,34 @@ pip install centralcli[speedups]
   # for zsh or others, do the equivalent... i.e. update .zshrc in a similar manner
   ```
 
-### Upgrading the CLI
+  Then to upgrade:
+```bash
+~/.venvs/centralcli/bin/pip install -U centralcli
+```
 
-`pip3 install -U centralcli`
+### pip (in system python environment)
+[Requires python3.9 or above and pip.](#if-you-dont-have-python)
+
+It's recommended to use the `uv` install method above, however if you don't use a lot of python apps (meaning a dependency conflict with other apps is not a concern).  Then simply installing via pip is possible (*albeit not recommended*).
+> This method is primarily feasible on Windows, as current versions of many Linux distributions do not allow installing apps in the system python environment.
+
+
+```bash
+pip install centralcli
+
+# optional install speedups for centralcli (this pulls in additional optional dependencies, that can improve performance.)  Minimal impact in most scenarios.
+pip install centralcli[speedups]
+```
+
+Then to upgrade:
+```bash
+pip install -U centralcli
+```
 
 ### if you don't have python
 
 - You can get it for any platform @ [https://www.python.org](https://www.python.org)
-- On Windows 10 it's also available in the Windows store.
+- On Windows 10 it's also available in the Windows store, and via winget.
 
 ## Configuration
 ✨ pre-populating the config as described below is optional.  Central CLI will prompt for the information it needs on first run if no config exists.

--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2711,6 +2711,8 @@ class Cache:
             doc_ids: int | List[int] = None,
             add: bool = False,
         ):
+        data = utils.listify(data)
+
         try:
             if doc_ids:
                 doc_ids = utils.listify(doc_ids)

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1281,6 +1281,40 @@ class CentralApi(Session):
 
         return await self.get(url, params=params)
 
+    async def create_device_template_variables(
+        self,
+        serial: str,
+        mac: str,
+        var_dict: dict,
+    ) -> Response:
+        """Create template variables for a device.
+
+        Args:
+            serial (str): Serial number of the device.
+            mac (str): MAC address of the device.
+            var_dict (dict): dict with variables to be updated
+
+        Returns:
+            Response: CentralAPI Response object
+        """
+        url = f"/configuration/v1/devices/{serial}/template_variables"
+
+        var_dict = {k: v for k, v in var_dict.items() if k not in ["_sys_serial", "_sys_lan_mac"]}
+        mac = utils.Mac(mac)
+
+        json_data = {
+            'total': len(var_dict) + 2,
+            "variables": {
+                **{
+                    '_sys_serial': serial,
+                    '_sys_lan_mac': mac.cols,
+                },
+                **var_dict
+            }
+        }
+
+        return await self.post(url, json_data=json_data)
+
 
     # TODO figure out how to make this work, need file like object
     async def update_device_template_variables(
@@ -1300,6 +1334,7 @@ class CentralApi(Session):
             Response: CentralAPI Response object
         """
         url = f"/configuration/v1/devices/{serial}/template_variables"
+        var_dict = {k: v for k, v in var_dict.items() if k not in ["_sys_serial", "_sys_lan_mac"]}
         # headers = {"Content-Type": "multipart/form-data"}
 
         json_data = {

--- a/centralcli/cliadd.py
+++ b/centralcli/cliadd.py
@@ -527,7 +527,7 @@ def template(
     name: str = typer.Argument(..., show_default=False,),
     group: str = typer.Argument(..., help="Group to upload template to", autocompletion=cli.cache.group_completion, show_default=False,),
     template: Path = typer.Argument(None, exists=True, show_default=False,),
-    dev_type: DevTypes = typer.Option("sw"),
+    dev_type: DevTypes = typer.Option(DevTypes.sw),
     model: str = typer.Option("ALL"),
     version: str = typer.Option("ALL", "--ver"),
     yes: bool = cli.options.yes,
@@ -544,7 +544,7 @@ def template(
 
     print(f"\n[bright_green]Add{'ing' if yes else ''} Template[/] [cyan]{name}[/] to group [cyan]{group.name}[/]")
     print("[bright_green]Template will apply to[/]:")
-    print(f"    Device Type: [cyan]{dev_type}[/]")
+    print(f"    Device Type: [cyan]{dev_type.value}[/]")
     print(f"    Model: [cyan]{model}[/]")
     print(f"    Version: [cyan]{version}[/]")
     if cli.confirm(yes):

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -116,8 +116,9 @@ def template(
     if cli.confirm(yes):
         resp = cli.central.request(cli.central.update_existing_template, **kwargs, template=template, payload=payload)
         cli.display_results(resp, tablefmt="action", exit_on_fail=True)
+        # will exit above if call failed.
         cache_template.data["template_hash"] = cli.central.request(cli.get_file_hash, file=template, string=payload)
-        _ = cli.central.request(cli.cache.update_template_db, data=cache_template)
+        _ = cli.central.request(cli.cache.update_template_db, data=cache_template.data)
 
 
 @app.command(help="Update existing or add new Variables for a device/template")

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -93,6 +93,8 @@ def template(
             cli.exit(f"Failed to determine template for {obj.name}.  Found: {len(_tmplt)}")
 
         cache_template = CacheTemplate(_tmplt[0])
+    else:
+        cache_template = obj
 
     kwargs = {
         "name": cache_template.name,
@@ -120,8 +122,8 @@ def template(
 
 @app.command(help="Update existing or add new Variables for a device/template")
 def variables(
-    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion),
-    var_value: List[str] = typer.Argument(..., help="comma seperated list 'variable = value, variable2 = value2'"),
+    device: str = typer.Argument(..., metavar=iden_meta.dev, autocompletion=cli.cache.dev_completion, show_default=False,),
+    var_value: List[str] = typer.Argument(..., help="comma seperated list 'variable = value, variable2 = value2'", show_default=False,),
     yes: bool = cli.options.yes,
     debug: bool = cli.options.debug,
     default: bool = cli.options.default,
@@ -149,16 +151,15 @@ def variables(
             get_next = False
 
     if len(vars) != len(vals):
-        typer.secho("something went wrong parsing variables.  Unequal length for Variables vs Values")
-        raise typer.Exit(1)
+        cli.exit("Something went wrong parsing variables.  Unequal length for Variables vs Values")
 
     var_dict = {k: v for k, v in zip(vars, vals)}
 
     con = Console(emoji=False)
     msg = "Sending Update" if yes else "Please Confirm: [bright_green]Update[/]"
     con.print(f"{msg} {dev.rich_help_text}")
-    [con.print(f'    {k}: [bright_green]{v}[/]') for k, v in var_dict.items()]
-    if yes or typer.confirm("\nProceed?", abort=True):
+    _ = [con.print(f'    {k}: [bright_green]{v}[/]') for k, v in var_dict.items()]
+    if cli.confirm(yes):
         resp = cli.central.request(
             cli.central.update_device_template_variables,
             serial,

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -1158,9 +1158,9 @@ class CombinedResponse(Response):
                 raw = {r.url.path: this_raw}
             else:
                 raw[r.url.path] = this_raw
-                if output_type == list:
+                if output_type is list:
                     output += this_output
-                elif output_type == dict:
+                elif output_type is dict:
                     output = {**output, **this_output}
                 else:
                     raise CentralCliException(f"flatten_resp received unexpected output attribute type {type(r.output)}.  Expected dict or list.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "7.3.4"
+version = "7.3.5"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
 - 📝 Add Known Issue regarding escape sequence warnings in python 3.12.  Change install instructions to use 3.11
 - 📝 Suggest uv as primary install method.
 - 🗃️ 🐛 Fix issue with template cache update after template is updated (had no ill effects, despite update failing as an update would only change the hash, which is not used by anything in the CLI)
 - 🐛 Fix bug when template specified by name in update template
 - 🐛 Fix corner-case issue where if group was provided to get_template_identifier it could return a match from a different group (if cache was outdated, and the same name was used in another group)
 - ✨ + `cencli add variables`
 - ✨ log.show can now print in color without putting markup in log
 - 💬 Improve confirmation formatting `delete template`