### PR TITLE
🔖v8.0.4

### DIFF
--- a/centralcli/cache.py
+++ b/centralcli/cache.py
@@ -2522,7 +2522,8 @@ class Cache:
             cache_by_serial = self.inventory_by_serial
 
         new_by_serial = {dev["serial"]: dev for dev in new_data}
-        updated_devs_by_serial = {**cache_by_serial, **new_by_serial}
+        # updated_devs_by_serial = {**cache_by_serial, **new_by_serial}
+        updated_devs_by_serial = {**cache_by_serial, **{serial: {**cache_by_serial[serial], **new_by_serial[serial]} for serial in new_by_serial}}
         return await self.update_db(DB, data=list(updated_devs_by_serial.values()), truncate=True)
 
 

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -4931,12 +4931,23 @@ class CentralApi(Session):
             services (str | List[str]): List of service names. Call services/config API to get the list of
                 valid service names.
 
+        Raises:
+            ValueError: When more the 50 serials are provided, which exceeds the max allowed by the API endpoint.
+
         Returns:
             Response: CentralAPI Response object
         """
         url = "/platform/licensing/v1/subscriptions/assign"
         serials = utils.listify(serials)
         services = utils.listify(services)
+
+        if len(serials) > 50:
+            raise ValueError(f"{url} endpoint allows a max of 50 serials per call.  {len(serials)} were provided.")
+
+        # Working code for doing 50 serial chunking here.  This results in _batch_request calling _batch_request and a list of lists.  Would need to flatted the lists
+        # for display_results to handle the output.
+        # requests = [self.BatchRequest(self.post, url, json_data={"serials": chunk, "services": services}) for chunk in utils.chunker(serials, 50)]
+        # return await self._batch_request(requests)
 
         json_data = {
             'serials': serials,
@@ -4953,12 +4964,18 @@ class CentralApi(Session):
             services (str | List[str]): List of service names. Call services/config API to get the list of
                 valid service names.
 
+        Raises:
+            ValueError: When more the 50 serials are provided, which exceeds the max allowed by the API endpoint.
+
         Returns:
             Response: CentralAPI Response object
         """
         url = "/platform/licensing/v1/subscriptions/unassign"
         serials = utils.listify(serials)
         services = utils.listify(services)
+
+        if len(serials) > 50:
+            raise ValueError(f"{url} endpoint allows a max of 50 serials per call.  {len(serials)} were provided.")
 
         json_data = {
             'serials': serials,

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -946,7 +946,10 @@ def get_devices(data: Union[List[dict], dict], *, verbosity: int = 0, output_for
 
     return data
 
-def get_audit_logs(data: List[dict], cache_update_func: callable = None) -> List[dict]:
+def get_audit_logs(data: List[dict], cache_update_func: callable = None, verbosity: int = 0) -> List[dict]:
+    if verbosity > 1:
+        return data  # No formatting with verbosity -vv
+
     field_order = [
         "id",
         "ts",
@@ -959,6 +962,10 @@ def get_audit_logs(data: List[dict], cache_update_func: callable = None) -> List
         "user",
         "has_details",
     ]
+
+    if not verbosity:
+        data = [inner for inner in data if inner.get("user") != "periodic_system_default_app_task"]
+
     data = [dict(short_value(k, d.get(k)) for k in field_order) for d in data]
     data = strip_no_value(data)
 

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -1429,7 +1429,7 @@ class CLICommon:
         _delay = 30
         for _try in range(4):
             _word = "more " if _try > 0 else ""
-            _prefix = "" if _try == 0 else escape("[Attempt {_try + 1}] ")
+            _prefix = "" if _try == 0 else escape(f"[Attempt {_try + 1}] ")
             _delay -= (5 * _try) # reduce delay by 5 secs for each loop
             for _ in track(range(_delay), description=f"{_prefix}[green]Allowing {_word}time for devices to disconnect."):
                 time.sleep(1)
@@ -1540,6 +1540,8 @@ class CLICommon:
             _total_reqs = len([*arch_reqs, *cop_del_reqs, *mon_del_reqs, *delayed_mon_del_reqs])
 
         if not _total_reqs:
+            if ui_only and delayed_mon_del_reqs:  # they select ui only, but devices are online
+                self.exit(f"[cyan]--ui-only[/] provided, but only applies to devices that are offline, {len(delayed_mon_del_reqs)} device{'s are' if len(delayed_mon_del_reqs) > 1 else ' is'} online.  Nothing to do. Exiting...")
             self.exit("[italic]Everything is as it should be, nothing to do.  Exiting...[/]", code=0)
 
         sin_plural = f"[cyan]{len(cache_found_devs)}[/] devices" if len(cache_found_devs) > 1 else "device"

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -443,6 +443,10 @@ class CLICommon:
         if code != 0:
             msg = f"[dark_orange3]\u26a0[/]  {msg}" if msg else msg  # \u26a0 = ⚠ / :warning:
 
+        # Display any log captions when exiting
+        if log.caption:
+            console.print(log.caption.lstrip().replace("\n  ", "\n"))
+
         if msg:
             console.print(msg)
         raise typer.Exit(code=code)
@@ -896,6 +900,9 @@ class CLICommon:
         # They can mark items as ignore or retired (True).  Those devices/items are filtered out.
         if isinstance(data, list) and all([isinstance(d, dict) for d in data]):
             data = [d for d in data if not d.get("retired", d.get("ignore"))]
+
+        if not data:
+            log.warning("No data after import from file.", caption=True)
 
         return data
 

--- a/centralcli/clishowaudit.py
+++ b/centralcli/clishowaudit.py
@@ -69,6 +69,15 @@ def acp_logs(
     start: datetime = cli.options(timerange="5d").start,
     end: datetime = cli.options.end,
     past: str = cli.options.past,
+    verbose: int = typer.Option(
+            0,
+            "-v",
+            count=True,
+            metavar="",
+            help="Verbosity: -v Show periodic system default app tasks, which are filtered by default, -vv Show logs with original field names and minimal formatting (vertically)",
+            rich_help_panel="Formatting",
+            show_default=False,
+    ),
     sort_by: LogSortBy = cli.options.sort_by,
     reverse: bool = cli.options.reverse,
     do_json: bool = cli.options.do_json,
@@ -81,7 +90,6 @@ def acp_logs(
     debug: bool = cli.options.debug,
     default: bool = cli.options.default,
     account: str = cli.options.account,
-    verbose: bool = typer.Option(False, "-v", help="Show logs with original field names and minimal formatting (vertically)"),
 ) -> None:
     """Show ACP audit logs
 
@@ -138,19 +146,20 @@ def acp_logs(
     if kwargs.get("log_id"):
         cli.display_results(resp, tablefmt="action")
     else:
-        tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if not verbose else "yaml")
+        tablefmt = cli.get_format(do_json, do_yaml, do_csv, do_table, default="rich" if verbose <= 1 else "yaml")
 
         cli.display_results(
             resp,
             tablefmt=tablefmt,
             title=title,
+            caption="Use [cyan]show audit acp-logs <id>[/] to see details for a log.  Logs lacking an id don't have details.",
             pager=pager,
             outfile=outfile,
             sort_by=sort_by,
             reverse=not reverse,  # API returns newest is on top this makes newest on bottom unless they use -r
-            cleaner=cleaner.get_audit_logs if not verbose else None,
-            cache_update_func=cli.cache.update_log_db if not verbose else None,
-            caption="Use [cyan]show audit acp-logs <id>[/] to see details for a log.  Logs lacking an id don't have details.",
+            cleaner=cleaner.get_audit_logs,  # if not verbose else None,
+            cache_update_func=cli.cache.update_log_db,  # cache is not updated if -vv if not verbose else None,
+            verbosity = verbose
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "8.0.3"
+version = "8.0.4"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
- ✨  🗃️ batch assign and unassign will now send requests 50 devices at a time per API limit.
     - Improve cache update after unsubscribe
- 🚑 Fix cache update regression when showing specific device types.
- 🐛 Prevent archive/unarchive calls in batch_delete if provided value is not a serial (dev not found).
- 🐛 Fix issue when anything other than serial provided to `cencli delete device`
- 💬 Add explanation when delete devices terminates do to --ui-only but all online
- 🚩 Add more verbosity options to `show audit acp-logs`
- 🔊 Display any log.captions when cli.exit is called
- 🚩 Add more verbosity options to `show audit acp-logs`