### PR TITLE
🔖 v8.0.5

### DIFF
--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -1724,7 +1724,7 @@ class CentralApi(Session):
         calculate_total: bool = False,
         sort: str = None,
         offset: int = 0,
-        limit: int = 100,
+        limit: int = 1000,
     ) -> Response:
         """List Sites.
 

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -1074,7 +1074,7 @@ def get_event_logs(data: List[dict], cache_update_func: callable = None) -> List
 def sites(data: Union[List[dict], dict]) -> Union[List[dict], dict]:
     data = utils.listify(data)
     data = Sites(data)
-    return data.model_dump()["sites"]
+    return data.model_dump()
 
 
 def get_certificates(data: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/centralcli/clibatch.py
+++ b/centralcli/clibatch.py
@@ -375,9 +375,15 @@ def batch_add_sites(import_file: Path = None, data: dict = None, yes: bool = Fal
         cli.exit("[italic dark_olive_green2]No Sites remain after validation[/].")
 
     resp = None
-    site_names = utils.summarize_list([s.site_name for s in verified_sites], max=7)
-    cli.console.print("\n[bright_green]The Following Sites will be created:[/]")
-    cli.console.print(site_names, emoji=False)
+    address_fields = {"site_name": "bright_green", "name": "bright_green", "address": "bright_cyan", "city": "turquoise4", "state": "dark_olive_green3", "country": "magenta", "zipcode": "blue", "zip": "blue"}
+    confirm_msg = utils.summarize_list(
+        [
+            "|".join([f'[{address_fields[k]}]{v}[/]' for k, v in site.items() if v and k in address_fields]) for site in verified_sites.model_dump()
+        ],
+        max=7
+    )
+    cli.console.print(f"\n[bright_green]The Following [cyan]{len(verified_sites)}[/] Sites will be created:[/]")
+    cli.console.print(confirm_msg, emoji=False)
     if cli.confirm(yes):
         reqs = [
             BatchRequest(central.create_site, **site.model_dump())
@@ -969,6 +975,7 @@ def add(
     if what == "sites":
         resp = batch_add_sites(import_file, yes=yes)
         tablefmt = "rich"
+        # TODO should re-order columns so output is more consistent with show sites (i.e. site_name is not guaranteed to be first col in output of these calls)
     elif what == "groups":
         resp = batch_add_groups(import_file, yes=yes)
     elif what == "devices":

--- a/centralcli/objects.py
+++ b/centralcli/objects.py
@@ -71,7 +71,10 @@ class DateTime():
             int | float: timestamp/epoch in seconds
         """
         if isinstance(timestamp, str):
-            return pendulum.parse(timestamp).timestamp()
+            if not timestamp.isdigit():
+                return pendulum.parse(timestamp).timestamp()
+            else:
+                timestamp = int(timestamp)
 
         if str(timestamp).isdigit() and len(str(int(timestamp))) > 10:
             timestamp = timestamp / 1000

--- a/centralcli/response.py
+++ b/centralcli/response.py
@@ -1085,7 +1085,7 @@ class Session():
         # strip out the pause/limiter (asyncio.sleep) responses (None)
         m_resp = utils.strip_none(m_resp)
 
-        log.debug(f"Batch Requests exec {len(api_calls)} calls, Total time {time.perf_counter() - _tot_start:.2f}")
+        log.info(f"Batch Requests exec {len(api_calls)} calls, Total time {time.perf_counter() - _tot_start:.2f}")
 
         self.silent = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "8.0.3"
+version = "8.0.4"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "centralcli"
-version = "8.0.4"
+version = "8.0.5"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = ["Wade Wells (Pack3tL0ss) <wade@consolepi.org>"]


### PR DESCRIPTION
🔖 v8.0.5
 - 🐛 Fix datetime parsing audit logs returned timestamp as str
 - 🐛 Fix bug with `cencli show site <site-name>` bug in cleaner due to change in model.
 - 🗃️ remove extra columns from ImportSite model
 - 💬 Provide more site details in confirmation msg for `batch add sites`
 - ⚡️ change default per-call limit in get_all_sites from 100 to 1000 (max)
 - 🔊 Change batch request total time log from debug to info