### PR TITLE
🔖 v8.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ keywords = [
     "RESTFUL",
     "REST"
 ]
+
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -59,7 +60,6 @@ speedups = [ "aiodns>=3.2.0;platform_system != 'Windows'", "Brotli;platform_pyth
 documentation = "https://central-api-cli.readthedocs.org"
 repository = "https://github.com/Pack3tL0ss/central-api-cli"
 issues = "https://github.com/Pack3tL0ss/central-api-cli/issues"
-
 
 [project.scripts]
 cencli = "centralcli.cli:app"


### PR DESCRIPTION
Previous commit had wrong version in the commit msg.  No real changes with this commit.  Just avoiding a force push.
- ✨ `show interfaces` can now show all interfaces across all devices of a provided type, with filtering options for site/group
- 📌 migrate pyproject.toml keys to current specification
- ⬆️ Update lock file