### PR TITLE
🔖 v8.2.5

### DIFF
--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -1233,7 +1233,7 @@ class CLICommon:
         # conductor_only option, as group move will move all associated devices when device is part of a swarm or stack
         cache_devs: List[CentralObject] = [self.cache.get_dev_identifier(d, include_inventory=True, conductor_only=True, silent=True, exit_on_fail=False) for d in dev_idens]
         not_found_devs: List[str] = [s for s, c in zip(dev_idens, cache_devs) if c is None]
-        cache_devs: List[CacheDevice | CacheInvDevice] = [d for d in cache_devs if d]
+        cache_devs: List[CacheDevice | CacheInvDevice] = [d for d in cache_devs if d is not None]
 
         if not_found_devs:
             not_in_inv_msg = utils.color(not_found_devs, color_str="cyan", pad_len=4, sep="\n")

--- a/centralcli/config.py
+++ b/centralcli/config.py
@@ -407,11 +407,11 @@ class Config:
                 last_account, timestamp of last cmd using this account, if initial will_forget_msg has been displayed, if account is expired
         """
         if self.sticky_account_file.is_file():
-            last_account_data = self.sticky_account_file.read_text().split("\n")
+            last_account_data = [row for row in self.sticky_account_file.read_text().split("\n") if row != ""]  # we don't add \n at end of file, but to handle it just in case
             if last_account_data:
                 last_account = last_account_data[0]
-                last_cmd_ts = float(last_account_data[1])
-                big_msg_displayed = bool(int(last_account_data[2]))
+                last_cmd_ts = self.sticky_account_file.stat().st_mtime if len(last_account_data) < 2 else float(last_account_data[1])
+                big_msg_displayed = False if len(last_account_data) < 3 else bool(int(last_account_data[2]))
                 expired = True if self.forget is not None and time.time() > last_cmd_ts + (self.forget * 60) else False
                 return last_account, last_cmd_ts, big_msg_displayed, expired
         return None, None, False, None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centralcli"
-version = "8.2.4"
+version = "8.2.5"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = [{"name" = "Wade Wells (Pack3tL0ss)","email" = "cencli@consolepi.com"}]


### PR DESCRIPTION
 - 🚑 handle last_account_file from older version of centralcli (fewer rows being stashed)
 - 🐛 Fix logic if var is not None vs if var, as __bool__ is configured for CacheObject so down devices could be ignored.
 - 🗃️ Improve cache update logic when device found only in inventory (refresh device cache, even if found in inventory)