### PR TITLE
🔖v8.5.0

### DIFF
--- a/.vscode/launch.json.bak
+++ b/.vscode/launch.json.bak
@@ -9,21 +9,21 @@
           "id": "cliArgs",
           "description": "Select Arguments",
           // The default is updated automatically by the script, could not get vscode debugger to do it.
-          "default": "show clients --rich"  // VSC_PREV_ARGS
+          "default": "update cp-cert le_may25 -G all"  // VSC_PREV_ARGS
         },
         {
             "type": "pickString",
             "id": "cliArgsHistory",
             "description": "Select Arguments",
             // The default is updated automatically by the script, could not get vscode debugger to do it.
-            "options": ["show clients --rich", "show clients", "show lldp neighbors br1 --rich", "show lldp neighbors br1", "show lldp neighbors 2930f-branch13", "show lldp 2930f-branch1", "show lldp neighbors 2930f-branch1", "show aps", "do update-vars bsmt-2930f if_2_nopoe = 0", "do cycle poe bsmt-2930f 4 -y"],  // VSC_ARG_HISTORY
-            "default": "show clients --rich"  // VSC_PREV_ARGS
+            "options": ["update cp-cert le_may25 -G all", "show certs 379f", "show cache certs", "show certs", "show clients -w -d", "show config FD-Comcast-Production --ap", "show config FD-Comcast-Production", "show config \u001b[200~~", "show groups --account fd", "batch delete devices /home/wade/git/myrepos/cencli-batch/aug-2024-retired-no-sub.yaml --dev-type gw"],  // VSC_ARG_HISTORY
+            "default": "update cp-cert le_may25 -G all"  // VSC_PREV_ARGS
           },
       ],
     "configurations": [
         {
             "name": "cli arg INPUT",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/centralcli/cli.py",
             "console": "integratedTerminal",
@@ -36,7 +36,7 @@
         },
         {
             "name": "cli arg INPUT Path Test",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${env:HOME}/git/myrepos/central-api-cli/centralcli/cli.py",
             "console": "integratedTerminal",
@@ -49,7 +49,7 @@
         },
         {
             "name": "code generator",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/.vscode/central_json_schemas/_gen_code.py",
             "console": "integratedTerminal",
@@ -61,7 +61,7 @@
         },
         {
             "name": "cli arg SELECT",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "cli.py",
             "console": "integratedTerminal",
@@ -71,7 +71,7 @@
         },
         {
             "name": "cli package debug",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${env:HOME}/.local/bin/cencli",
             "console": "integratedTerminal",
@@ -82,7 +82,7 @@
         },
         {
             "name": "DEVCLI interactive arg selection",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "devcli.py",
             "console": "integratedTerminal",
@@ -92,7 +92,7 @@
         },
         {
             "name": "test_show",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/tests/test_show.py",
             "console": "integratedTerminal",
@@ -104,7 +104,7 @@
         // could not get it to work.  Not via debugger (even with "envFile": "${workspaceFolder}/.env",)
         {
             "name": "cli interactive arg selection WIP",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "cli.py",
             "console": "integratedTerminal",
@@ -114,7 +114,7 @@
         },
         {
             "name": "Python: central.py bulk-edit",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "lib/centralCLI/central.py",
             "console": "integratedTerminal",
@@ -125,7 +125,7 @@
         },
         {
             "name": "Python: cli.py interactive",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "cli.py",
             "console": "integratedTerminal",
@@ -136,7 +136,7 @@
         },
         {
             "name": "Python: cli.py bulk-edit",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "cli.py",
             "console": "integratedTerminal",
@@ -147,7 +147,7 @@
         },
         {
             "name": "Python: cli.py show dev gateways",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "cli.py",
             "console": "integratedTerminal",
@@ -158,7 +158,7 @@
         },
         {
             "name": "Python: Current File",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal"

--- a/centralcli/boilerplate/allcalls.py
+++ b/centralcli/boilerplate/allcalls.py
@@ -217,7 +217,7 @@ class AllCalls(CentralApi):
         url = f"/aiops/v1/connectivity/global/stage/{stage}/export"
 
         params = {
-            'from_ms': from_ms,
+            'from': from_ms,
             'to': to
         }
 

--- a/centralcli/central.py
+++ b/centralcli/central.py
@@ -5549,7 +5549,7 @@ class CentralApi(Session):
 
         return [*update_resp, *skipped, *list(failed.values())]
 
-    async def _update_cp_cert_in_config(self, data: List[str], cp_cert_md5: str) -> List[str] | None:
+    async def _update_cp_cert_in_config(self, data: List[str], cp_cert_md5: str,) -> List[str] | None:
             """Updates cp-cert-checksum in AP group level config
 
             Args:
@@ -5576,9 +5576,11 @@ class CentralApi(Session):
                 if line_index:
                     line_index = line_index[0]
                     _ = cli_cmds.pop(line_index)
+                    log.debug(f"Removed {_} from config")
                 else:  # cp-cert-checksum does not exist in the config
                     line_index = cli_cmds.index("cluster-security")
                 cli_cmds.insert(line_index, f"cp-cert-checksum {cp_cert_md5}")
+                log.debug(f'Added "cp-cert-checksum {cp_cert_md5}" to line {line_index + 1} of the config')
 
             return cli_cmds
 

--- a/centralcli/cleaner.py
+++ b/centralcli/cleaner.py
@@ -2099,3 +2099,9 @@ def show_ai_insights(data: List[Dict[str, str | bool | int]], severity: InsightS
         data = [{k: v for k, v in inner.items() if inner.get("severity") is None or inner["severity"] == severity} for inner in data]
 
     return simple_kv_formatter(data, key_order=field_order, strip_null=True, emoji_bools=True, show_false=False)
+
+def get_dirty_diff(data: List[Dict[str, str]],) -> List[Dict[str, str]]:
+    if not data:
+        return data
+
+    return [{"ap": f"{item.get('name', 'err-no-name-field')} [dim]({item.get('id', 'err-no-id-field')})[/]", "dirty diff": item["dirty_diff"]} for item in data]

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -1302,7 +1302,7 @@ class CLICommon:
                 self.exit("No devices found")
 
 
-        site_rm_reqs, batch_reqs, confirm_msgs = [], [], [""]
+        site_rm_reqs, batch_reqs, confirm_msgs = [], [], []
         if do_site:
             site_ops = self._check_site(cache_devs=cache_devs, import_data=devices)
             batch_reqs += site_ops.move.reqs
@@ -1325,7 +1325,7 @@ class CLICommon:
         if _tot_req > 1:
             confirm_msgs += [f"\n[italic dark_olive_green2]Will result in {_tot_req} additional API Calls."]
 
-        clean_console.print("\n".join(confirm_msgs))
+        clean_console.print("\n".join(confirm_msgs).strip())  # stripping as we have a \n before and after coming from somewhere.
         if self.confirm(yes):
             site_rm_res = []
             if site_rm_reqs:

--- a/centralcli/clicommon.py
+++ b/centralcli/clicommon.py
@@ -161,6 +161,8 @@ class CLICommon:
         if not result and abort:
             self.econsole.print("[red]Aborted[/]")
             self.exit(code=0)
+        elif yes:  # The default prompt has a newline before the prompt, this is so -y without prompt still gets a newline to avoid jamming the response text with the confirmation msg.
+            print()
 
         return result
 

--- a/centralcli/clioptions.py
+++ b/centralcli/clioptions.py
@@ -164,8 +164,8 @@ class CLIOptions:
     def get(
         self,
         option: str,
+        *param_decls,
         default: Optional[Any] = None,
-        *,
         callback: Optional[Callable[..., Any]] = None,
         metavar: Optional[str] = None,
         expose_value: bool = None,
@@ -279,7 +279,8 @@ class CLIOptions:
         }
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         combined = {**attr.__dict__, **kwargs}
-        args = (combined["default"], *combined["param_decls"])
+        param_decls = param_decls or combined["param_decls"]
+        args = (combined["default"], *param_decls)
         kwargs_out = {k: v for k, v in combined.items() if k not in ["default", "param_decls"]}
         return typer.Option(*args, **kwargs_out)
 

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -2102,7 +2102,14 @@ def config_(
         if device:
             device: CacheDevice = cli.cache.get_dev_identifier(device)
         elif not do_ap and not do_gw:
-            cli.exit("Invalid Input, --gw or --ap option must be supplied for group level config.")
+            if "ap" in group_dev.allowed_types and "gw" in group_dev.allowed_types:
+                cli.exit("Invalid Input, --gw or --ap option must be supplied for group level config.")
+            elif "ap" in group_dev.allowed_types:
+                cli.econsole.print(f"[yellow]:information:[/]  Assuming [cyan]--ap[/] as [magenta]dev type[/]: [cyan]gw[/] is not configured for group [cyan]{group_dev.name}[/].\n")
+                do_ap = True
+            elif "gw" in group_dev.allowed_types:
+                cli.econsole.print(f"[yellow]:information:[/]  Assuming [cyan]--gw[/] as [magenta]dev type[/]: [cyan]ap[/] is not configured for group [cyan]{group_dev.name}[/].\n")
+                do_gw = True
     else:  # group_dev is a device iden
         group = cli.cache.get_group_identifier(group_dev.group)
         if device is not None:

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -567,7 +567,7 @@ def aps(
         group = cli.cache.get_group_identifier(group)
         resp = cli.central.request(cli.central.get_dirty_diff, group.name)
         tablefmt: str = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
-        cli.display_results(resp, tablefmt=tablefmt, title=f"AP config items that have not pushed for group {group.name}", pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse)
+        cli.display_results(resp, tablefmt=tablefmt, title=f"AP config items that have not pushed for group {group.name}", pager=pager, outfile=outfile, sort_by=sort_by, group_by="ap", reverse=reverse, cleaner=cleaner.get_dirty_diff)
     elif neighbors:
         if site is None:
             cli.exit("[cyan]--site <site name>[/] is required for neighbors output.")

--- a/centralcli/clishow.py
+++ b/centralcli/clishow.py
@@ -896,7 +896,6 @@ def subscriptions(
     )
 
 
-# TODO need sort_by enum
 @app.command()
 def swarms(
     ap: str = typer.Argument(None, metavar=iden_meta.dev, help=f"Show settings for the Virtual Controller/Swarm associated with this AP.  {cli.help_block('Show All Swarms')}", show_default=False, autocompletion=cli.cache.dev_ap_completion),
@@ -1932,7 +1931,15 @@ def lldp(
 
 @app.command(short_help="Show certificates/details")
 def certs(
-    name: str = typer.Argument(None, metavar='[certificate name|certificate hash]',),
+    query: str = typer.Argument(None, metavar='[name|hash]', autocompletion=cli.cache.cert_completion, help="Show details for certificates matching query [dim italic]name or hash[/]", show_default=False,),
+    valid: bool = typer.Option(None, help="Filter by certificate validity [dim italic]expiration status[/]", show_default=False,),
+    server_cert: bool = typer.Option(None, "--svr", help="Filter by certificate type: Server Certificate", show_default=False,),
+    ca_cert: bool = typer.Option(None, "--ca", help="Filter by certificate type: CA", show_default=False,),
+    crl: bool = typer.Option(None, "--crl", help="Filter by certificate type: CRL", show_default=False,),
+    int_ca_cert: bool = typer.Option(None, "--int-ca", help="Filter by certificate type: Intermediate CA", show_default=False,),
+    ocsp_resp_cert: bool = typer.Option(None, "--ocsp-resp", help="Filter by certificate type: OCSP responder", show_default=False,),
+    ocsp_signer_cert: bool = typer.Option(None, "--ocsp-signer", help="Filter by certificate type: OCSP signer", show_default=False,),
+    ssh_pub_key: bool = typer.Option(None, "--public", help="Filter by certificate type: SSH Public cert", show_default=False, hidden=True,),
     sort_by: SortCertOptions = cli.options.sort_by,
     reverse: bool = cli.options.reverse,
     do_json: bool = cli.options.do_json,
@@ -1946,11 +1953,21 @@ def certs(
     default: bool = cli.options.default,
     account: str = cli.options.account,
 ) -> None:
-    resp = cli.central.request(cli.central.get_certificates, name, callback=cleaner.get_certificates)
+    resp = cli.central.request(cli.cache.refresh_cert_db, query)
     tablefmt = cli.get_format(do_json=do_json, do_yaml=do_yaml, do_csv=do_csv, do_table=do_table, default="rich")
+    type_filter = {
+        "SERVER_CERT": server_cert,
+        "CA_CERT": ca_cert,
+        "CRL": crl,
+        "INTERMEDIATE_CA": int_ca_cert,
+        "OCSP_RESPONDER_CERT": ocsp_resp_cert,
+        "OCSP_SIGNER_CERT": ocsp_signer_cert,
+        "PUBLIC_CERT": ssh_pub_key
+    }
+    cert_types = [k for k, v in type_filter.items() if v is True]
 
     cli.display_results(
-        resp, tablefmt=tablefmt, title="Certificates", pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse
+        resp, tablefmt=tablefmt, title="Certificates", pager=pager, outfile=outfile, sort_by=sort_by, reverse=reverse, cleaner=cleaner.get_certificates, valid=valid, cert_types=cert_types
     )
 
 # TODO show task --device  look up task by device if possible
@@ -3002,7 +3019,7 @@ def last(
     kwargs["tablefmt"] = cli.get_format(do_json, do_yaml, do_csv, do_table, default=last_format)
     if not kwargs.get("title") or "Previous Output" not in kwargs["title"]:
         kwargs["title"] = f"{kwargs.get('title') or ''} Previous Output " \
-                        f"{cleaner._convert_epoch(int(config.last_command_file.stat().st_mtime))}"  # Update to use DateTime
+                        f"{DateTime(int(config.last_command_file.stat().st_mtime))}"
     data = kwargs["outdata"]
     del kwargs["outdata"]
 

--- a/centralcli/clishowaudit.py
+++ b/centralcli/clishowaudit.py
@@ -256,7 +256,7 @@ def logs(
 
     if log_id is not None:
         if resp and "body" in resp.output:
-            body = utils.unlistify(resp.output["body"])
+            body = utils.unlistify(resp.output["body"], replace_underscores=False)
             if body:
                 body = body.replace("\t", "  ")
                 body = f'  body:\n    {"    ".join(body.splitlines(keepends=True))}'

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -337,6 +337,8 @@ def config_(
 
 
 # FIXME typer is not handling List[str] as expected.  Change groups metevar back to iden_meta.group_many once sorted.
+# TODO check... Default for group ATM-LOCAL had "wlan cert-assignment-profile" no sub-commands below it...  it did not have "cp-cert-checksum ..."
+#   update cp-cert ... added cp-cert-checksum, which removed "wlan cert-assignment-profile".  Need to verify what that is, thought the default was cp-cert-checksum pointing to default aruba cert.
 @app.command()
 def cp_cert(
     certificate: str = typer.Argument(

--- a/centralcli/cliupdate.py
+++ b/centralcli/cliupdate.py
@@ -29,7 +29,7 @@ except (ImportError, ModuleNotFoundError) as e:
 
 from .constants import IdenMetaVars, DevTypes, GatewayRole, NotifyToArgs, state_abbrev_to_pretty, RadioBandOptions, DynamicAntMode, IAPTimeZoneNames
 from . import render
-from .cache import CacheTemplate, CacheDevice, CacheGroup, CachePortal
+from .cache import CacheTemplate, CacheDevice, CacheGroup, CachePortal, CacheCert
 from .caas import CaasAPI
 
 
@@ -334,6 +334,61 @@ def config_(
         else:
             resp = cli.central.request(cli.central.replace_ap_config, node_iden, cli_cmds)
             cli.display_results(resp, tablefmt="action")
+
+
+# FIXME typer is not handling List[str] as expected.  Change groups metevar back to iden_meta.group_many once sorted.
+@app.command()
+def cp_cert(
+    certificate: str = typer.Argument(
+        ...,
+        help="The certificate name or md5 checksum to use for Captive Portal. [dim italic red]Certificate must exist[/]",
+        autocompletion=cli.cache.cert_completion,
+        show_default=False,
+    ),
+    groups: List[str] = cli.options.get(
+        "group_many", "-G", "--group",
+        default=...,
+        metavar=iden_meta.group.replace("NAME]", "NAME|all]"),
+        help="The Group [dim italic](AP Group)[/] to be updated to use the Captive Portal certificate. [dark_orange3]:warning:[/]  [cyan]all[/] Will push to all AP groups",
+        autocompletion=cli.cache.group_ap_completion
+    ),
+    yes: bool = cli.options.yes,
+    debug: bool = cli.options.debug,
+    default: bool = cli.options.default,
+    account: str = cli.options.account,
+) -> None:
+    """Update the Captive Portal certificate for APs at the group level
+
+    This will update the certificate usage (cp-cert-checksum) at the group level (for APs) to reference the specified certificate.
+    The certificate must be uploaded to Aruba Central first.  Use [cyan]cencli add certificate[/] to upload the certificate.
+    and [cyan]cencli show certs[/] to see the available certificates.
+
+    [dark_orange3]:warning:[/]  "--group|-G [red]all[/]" Will update Captive Portal certificate usage for **all** AP groups.
+
+    :information:  Not supported on Template Groups.  [dim italic](They are filtered out if [cyan]all[/] is specified)[/]
+    """
+    cert: CacheCert = cli.cache.get_cert_identifier(certificate)
+    if groups != ["all"]:
+        groups: List[CacheGroup] = [cli.cache.get_group_identifier(g, dev_type="ap") for g in groups]
+    else:
+        groups: List[CacheGroup] = cli.cache.ap_groups
+
+    # filter out Template Groups and CNX managed groups.
+    groups = [g for g in groups if g.cnx is not True and not g.wlan_tg]
+
+    _confirm_msg = f"Updat{'ing' if yes else 'e'} Captive Portal Certificate to {cert.name}|checksum: {cert.md5_checksum}\n  "
+    if len(groups) > 1:
+        _groups_txt = utils.color([g.name for g in groups], pad_len=4, sep='\n')
+        _confirm_msg += f"in the following {len(groups)} groups:\n{_groups_txt}"
+        _confirm_msg += f"\n\n[italic dark_olive_green2]Operation will result in {len(groups) * 2} API Calls."
+    else:
+        _confirm_msg += f"in group [bright_green]{groups[0].name}[/]"
+    cli.console.print(_confirm_msg)
+
+    cli.confirm(yes)
+    group_names = [g.name for g in groups]
+    resp = cli.central.request(cli.central.update_group_cp_cert, group_names, cp_cert_md5=cert.md5_checksum)
+    cli.display_results(resp, tablefmt="action")
 
 
 @app.command(hidden=True)

--- a/centralcli/constants.py
+++ b/centralcli/constants.py
@@ -404,6 +404,7 @@ class CacheArgs(str, Enum):
     portals = "portals"
     tables = "tables"
     guests = "guests"
+    certs = "certs"
 
 
 class KickArgs(str, Enum):

--- a/centralcli/logger.py
+++ b/centralcli/logger.py
@@ -6,7 +6,6 @@ from typing import Union, List, Any
 from logging.handlers import RotatingFileHandler
 from time import sleep
 from rich.console import Console
-from rich.markup import escape
 # from rich.logging import RichHandler
 
 import logging

--- a/centralcli/typedefs.py
+++ b/centralcli/typedefs.py
@@ -29,6 +29,8 @@ CacheTableName = Literal["devices", "sites", "groups", "labels", "macs", "mpsk"]
 DynamicAntenna = Literal["narrow", "wide"]
 RadioType = Literal["2.4", "5", "6"]
 MPSKStatus = Literal["enabled", "disabled"]
+CertType = Literal["SERVER_CERT", "CA_CERT", "CRL", "INTERMEDIATE_CA", "OCSP_RESPONDER_CERT", "OCSP_SIGNER_CERT", "PUBLIC_CERT"]
+CertFormat = Literal["PEM", "DER", "PKCS12"]
 
 # StrEnum available python 3.11+
 try:

--- a/centralcli/utils.py
+++ b/centralcli/utils.py
@@ -228,19 +228,19 @@ class Utils:
         return var if isinstance(var, list) or var is None else [var]
 
     @staticmethod
-    def unlistify(data: Any):
+    def unlistify(data: Any, replace_underscores: bool = True):
         """Remove unnecessary outer lists.
 
         Returns:
             [] = ''
-            ['single_item'] = 'single item'
+            ['single_item'] = 'single item' by default 'single_item' if replace_underscores=False
             [[item1], [item2], ...] = [item1, item2, ...]
         """
         if isinstance(data, list):
             if not data:
                 data = ""
             elif len(data) == 1:
-                data = data[0] if not isinstance(data[0], str) else data[0].replace("_", " ")
+                data = data[0] if not replace_underscores or not isinstance(data[0], str) else data[0].replace("_", " ")
             elif all([isinstance(d, list) and len(d) == 1 for d in data]):
                 out = [i for ii in data for i in ii if not isinstance(i, list)]
                 if out:

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 @nox.session(python=['venv3.9/bin/python3', 'venv3.10/bin/python3', 'venv3.11/bin/python3', 'venv3.12/bin/python3', 'venv3.13/bin/python3'])
 def tests(session):
-    requirements = nox.project.load_toml("pyproject.toml")["project"]["dependencies"]
+    deps = nox.project.load_toml("pyproject.toml")["project"]["dependencies"]
+    speedups = nox.project.load_toml("pyproject.toml")["project"]["optional-dependencies"]["speedups"]
+    requirements = [*deps, *speedups]
     session.install(*requirements)
     session.install('pytest')
     session.run('pytest')

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,14 @@
+import nox
+from pathlib import Path
+
+@nox.session(python=['venv3.9/bin/python3', 'venv3.10/bin/python3', 'venv3.11/bin/python3', 'venv3.12/bin/python3', 'venv3.13/bin/python3'])
+def tests(session):
+    requirements = nox.project.load_toml("pyproject.toml")["project"]["dependencies"]
+    session.install(*requirements)
+    session.install('pytest')
+    session.run('pytest')
+
+@nox.session()
+def lint(session):
+    session.install('ruff')
+    session.run('ruff', 'check', Path(__file__).parent / 'centralcli', '--config', Path(__file__).parent / 'pyproject.toml')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 181
+exclude = ["dashboard", "wh_proxy_service.py"]
 # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centralcli"
-version = "8.4.2"
+version = "8.5.0"
 description = "A CLI for interacting with Aruba Central (Cloud Management Platform).  Facilitates bulk imports, exports, reporting.  A handy tool if you have devices managed by Aruba Central."
 license = "MIT"
 authors = [{"name" = "Wade Wells (Pack3tL0ss)","email" = "cencli@consolepi.com"}]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 ruff
 pytest
+nox


### PR DESCRIPTION
 - ✨ 🗃️ Certificates are now cached.  `cencli show certs` supports a ton more filtering flags
 - ✨ Add `cencli update cp-cert` to update the Captive Portal certificate @ AP group level.  For 1 or all AP groups.
 - ✨ `cencli show config <group>` will now make logical assumption on --ap/--gw if not provided.  Based on the groups allowed_types.
 - ♻️ 'cencli show certificates' now uses our DateTime object for expiration field, so sorting on the field works correctly.    
 - ⚰️ Remove remaining 2 references to old time converters, and remove those functions.  All time fields should be using DateTime object now.
 - 🩹 Fix underscores being replaced with spaces in log detail body for `show audit logs <log id>`
 - 🔊 Add debug logging showing lines added/removed from AP group level config when updating cp-cert-checksum
 - 💬 Minor change in spacing `\n` for confirmation and output in device move commands
 - 💬 Add cleaner for `cencli show aps --group <group> --dirty`
 - 🔧 Update example launch.json for dev
 - ✅ Test with optional dependencies "speedups"
 - ✅ Add nox and configuration for automating tests across different python versions.    
    `uv venv venv3.9 --python 3.9 --seed` (repeated for each version we support) was used to create the various interpreters/versions.
